### PR TITLE
Declare `after_submit` callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- The `after_submit` callbacks, along with request-level block versions, and the
+  specialized `with_status:` version (added by [@seanpdoyle][])
+
+[@seanpdoyle]: https://github.com/seanpdoyle

--- a/lib/action_client/after_submit_error.rb
+++ b/lib/action_client/after_submit_error.rb
@@ -1,0 +1,3 @@
+module ActionClient
+  class AfterSubmitError < ActionClient::Error; end
+end

--- a/lib/action_client/callbacks/after_submit.rb
+++ b/lib/action_client/callbacks/after_submit.rb
@@ -1,0 +1,35 @@
+module ActionClient
+  module Callbacks
+    class AfterSubmit
+      def initialize(app, matching_status_codes = nil, &block)
+        @app = app
+        @http_status_filter = HttpStatusFilter.new(matching_status_codes)
+        @block = block
+      end
+
+      def call(env)
+        status_code, headers, body = app.call(env)
+
+        if http_status_filter.include?(status_code)
+          callback = callback_factory.new(status_code, headers, body)
+
+          callback.call(block)
+        else
+          [ status_code, headers, body ]
+        end
+      end
+
+      private
+
+      attr_reader :app, :block, :http_status_filter
+
+      def callback_factory
+        if block.arity == 1
+          SingleArgumentCallback
+        else
+          TripleArgumentCallback
+        end
+      end
+    end
+  end
+end

--- a/lib/action_client/callbacks/http_status_filter.rb
+++ b/lib/action_client/callbacks/http_status_filter.rb
@@ -1,0 +1,17 @@
+module ActionClient
+  module Callbacks
+    class HttpStatusFilter
+      delegate_missing_to :status_codes
+
+      def initialize(http_status)
+        @status_codes = Array(http_status || (100..599)).map do |status|
+          Rack::Utils.status_code(status)
+        end
+      end
+
+      private
+
+      attr_reader :status_codes
+    end
+  end
+end

--- a/lib/action_client/callbacks/single_argument_callback.rb
+++ b/lib/action_client/callbacks/single_argument_callback.rb
@@ -1,0 +1,18 @@
+module ActionClient
+  module Callbacks
+    SingleArgumentCallback = Struct.new(:status, :headers, :body) do
+      def call(block)
+        modified_body = block.call(body).tap do |response|
+          if response.nil?
+            raise ActionClient::AfterSubmitError, <<~ERROR
+              Callbacks declared with a single argument must return
+              a single body value, but this invocation returns nil
+            ERROR
+          end
+        end
+
+        [status, headers, modified_body]
+      end
+    end
+  end
+end

--- a/lib/action_client/callbacks/triple_argument_callback.rb
+++ b/lib/action_client/callbacks/triple_argument_callback.rb
@@ -1,0 +1,21 @@
+module ActionClient
+  module Callbacks
+    TripleArgumentCallback = Struct.new(:status, :headers, :body) do
+      def call(block)
+        block.call(status, headers, body).tap do |response|
+          response = Array(response)
+
+          if response.length != 3
+            raise ActionClient::AfterSubmitError, <<~ERROR
+              Callbacks declared with three arguments must return a Rack triplet,
+              but this invocation only returns #{response.length}:
+
+                #{response.inspect}
+
+            ERROR
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/action_client/engine.rb
+++ b/lib/action_client/engine.rb
@@ -1,13 +1,11 @@
 module ActionClient
   class Engine < ::Rails::Engine
-    config.action_client = ActiveSupport::OrderedOptions.new
-
     initializer "action_client.dependencies" do |app|
       ActionClient::Base.append_view_path app.paths["app/views"]
     end
 
     initializer "action_client.middleware" do
-      config.action_client.middleware = ActionDispatch::MiddlewareStack.new do |stack|
+      ActionClient::Base.middleware = ActionDispatch::MiddlewareStack.new do |stack|
         stack.use ActionClient::Middleware::ResponseParser
         stack.use Rack::ContentLength
         stack.use Rails::Rack::Logger, [ActionClient::Middleware::Tagger]

--- a/lib/action_client/error.rb
+++ b/lib/action_client/error.rb
@@ -1,0 +1,3 @@
+module ActionClient
+  class Error < StandardError; end
+end

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -4,24 +4,6 @@ require "integration_test_case"
 module ActionClient
   class ClientTestCase < ActionClient::IntegrationTestCase
     Article = Struct.new(:id, :title)
-
-    def declare_client(controller_path = nil, &block)
-      Class.new(ActionClient::Base).tap do |client_class|
-        if controller_path.present?
-          client_class.class_eval <<~RUBY
-          def self.controller_path
-            #{controller_path.inspect}
-          end
-          RUBY
-        end
-
-        client_class.class_eval(&block)
-      end
-    end
-
-    setup do
-      ActionClient::Base.defaults = ActiveSupport::OrderedOptions.new
-    end
   end
 
   class ActionMethodsTest < ClientTestCase

--- a/test/integration/action_client/callbacks_test.rb
+++ b/test/integration/action_client/callbacks_test.rb
@@ -1,0 +1,352 @@
+require "test_helper"
+require "integration_test_case"
+
+module ActionClient
+  class CallbacksTest < ActionClient::IntegrationTestCase
+    test "executes code declared in an after_submit callback" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"error": "failed"}),
+        headers: { "Content-Type": "application/json" },
+        status: 422,
+      )
+      client = declare_client do
+        after_submit do |status, headers, body|
+          if status == 422
+            raise ArgumentError, body.fetch("error")
+          end
+        end
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      assert_raises ArgumentError, "failed" do
+        client.create.submit
+      end
+    end
+
+    test "after_submit executes on the body when passed a single argument" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"status": "created"}),
+        headers: { "Content-Type" => "application/json" },
+        status: 201,
+      )
+      client = declare_client do
+        after_submit { |body| body.with_indifferent_access }
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      status, headers, body = *client.create.submit
+
+      assert_equal 201, status
+      assert_equal "application/json", headers["Content-Type"]
+      assert_equal "created", body.fetch(:status)
+    end
+
+    test "can modify the response from an after_submit callback" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"status": "created"}),
+        headers: { "Content-Type" => "application/json" },
+        status: 200,
+      )
+      client = declare_client do
+        after_submit do |_, _, body|
+          body["status"] = "modified"
+          [
+            201,
+            { "Content-Type" => "application/json" },
+            body,
+          ]
+        end
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      status, headers, body = *client.create.submit
+
+      assert_equal 201, status
+      assert_equal "application/json", headers["Content-Type"]
+      assert_equal "modified", body.fetch("status")
+    end
+
+    test "executes after_submit callbacks in the order they're declared" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"status": "modified"}),
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      )
+      client = declare_client do
+        after_submit { |status, headers, body| body["status"] = "modified"; [status, headers, body] }
+        after_submit { |status, headers, body| [status, headers, body.transform_keys(&:upcase)] }
+
+        def create
+          post url: "https://example.com/articles" do |status, headers, body|
+            [status, headers, body.with_indifferent_access]
+          end
+        end
+      end
+
+      response = client.create.submit
+
+      assert_equal "modified", response.body.fetch(:STATUS)
+    end
+
+    test "can declare a request-specific after_submit accepting a Rack triplet" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"status": "created"}),
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      )
+      client = declare_client do
+        def create
+          post url: "https://example.com/articles" do |status, headers, body|
+            body["status"] = "modified"
+            [status, headers, body]
+          end
+        end
+      end
+
+      response = client.create.submit
+
+      assert_equal "modified", response.body.fetch("status")
+    end
+
+    test "can declare a request-specific after_submit accepting the body" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"status": "created"}),
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      )
+      client = declare_client do
+        def create
+          post url: "https://example.com/articles" do |body|
+            body.with_indifferent_access
+          end
+        end
+      end
+
+      status, headers, body = *client.create.submit
+
+      assert_equal 200, status
+      assert_equal "application/json", headers["Content-Type"]
+      assert_equal "created", body.fetch(:status)
+    end
+
+    test "does not execute after_submit blocks that don't match the status" do
+      stub_request(:post, "https://example.com/articles").and_return(status: 200)
+      client = declare_client do
+        after_submit with_status: 422 do |status, headers, body|
+          raise ArgumentError
+        end
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      response = client.create.submit
+
+      assert_equal 200, response.status
+    end
+
+    test "can declare an after_submit callback matching the status code" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"error": "failed"}),
+        headers: { "Content-Type": "application/json" },
+        status: 422,
+      )
+      client = declare_client do
+        after_submit with_status: 422 do |status, headers, body|
+          raise ArgumentError, body.fetch("error")
+        end
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      assert_raises ArgumentError, "failed" do
+        client.create.submit
+      end
+    end
+
+    test "can match an after_submit callback with a mixture of Numeric and Symbol status codes" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"error": "failed"}),
+        headers: { "Content-Type": "application/json" },
+        status: 401,
+      )
+      client = declare_client do
+        after_submit with_status: [:unauthorized, 403] do |body|
+          raise ArgumentError, body.fetch("error")
+        end
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      assert_raises ArgumentError, "failed" do
+        client.create.submit
+      end
+    end
+
+    test "can pass only the body to the block of an after_submit callback declaring a matching status code" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"error": "failed"}),
+        headers: { "Content-Type": "application/json" },
+        status: 422,
+      )
+      client = declare_client do
+        after_submit with_status: 422 do |body|
+          raise ArgumentError, body.fetch("error")
+        end
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      assert_raises ArgumentError, "failed" do
+        client.create.submit
+      end
+    end
+
+    test "can after_submit a callback that declares an Array containing the status code" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"error": "failed"}),
+        headers: { "Content-Type": "application/json" },
+        status: 401,
+      )
+      client = declare_client do
+        after_submit with_status: [401, 403] do |status, headers, body|
+          raise ArgumentError, body.fetch("error")
+        end
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      assert_raises ArgumentError, "failed" do
+        client.create.submit
+      end
+    end
+
+    test "can after_submit a callback that decalares a Range of matching status codes" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        body: %({"error": "failed"}),
+        headers: { "Content-Type": "application/json" },
+        status: 422,
+      )
+      client = declare_client do
+        after_submit with_status: 400..500 do |status, headers, body|
+          raise ArgumentError, body.fetch("error")
+        end
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      assert_raises ArgumentError, "failed" do
+        client.create.submit
+      end
+    end
+
+    test "each time a request is submitted, it receives its own middleware stack" do
+      client = declare_client do
+        after_submit do |body|
+          body["callbacks"].push("class")
+          body
+        end
+
+        def create
+          post url: "https://example.com/articles" do |body|
+            body["callbacks"].push("create")
+            body
+          end
+        end
+
+        def destroy
+          delete url: "https://example.com/articles/1" do |body|
+            body["callbacks"].push("destroy")
+            body
+          end
+        end
+
+        def all
+          get url: "https://example.com/articles"
+        end
+      end
+      stub_request(:any, %r{example.com}).to_return(
+        headers: { "Content-Type": "application/json" },
+        body: { callbacks: [] }.to_json,
+      )
+
+      create_response = client.create.submit
+      destroy_response = client.destroy.submit
+      all_response = client.all.submit
+
+      assert_equal ["class", "create"], create_response.body["callbacks"]
+      assert_equal ["class", "destroy"], destroy_response.body["callbacks"]
+      assert_equal ["class"], all_response.body["callbacks"]
+    end
+  end
+
+  class CallbackErrorsTest < ActionClient::IntegrationTestCase
+    test "raises an exception when the block does not return a triplet" do
+      stub_request(:post, "https://example.com/articles")
+      client = declare_client do
+        after_submit { |status, headers, body| body }
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      assert_raises ActionClient::AfterSubmitError, /Rack triplet/ do
+        client.create.submit
+      end
+    end
+
+    test "does not raise an exception when a single argument block returns an Array of 1 item" do
+      client = declare_client do
+        def all
+          get url: "https://example.com/articles" do |body|
+            body.map(&:symbolize_keys)
+          end
+        end
+      end
+      stub_request(:get, %r{example.com}).to_return(
+        headers: { "Content-Type": "application/json" },
+        body: [{ id: 1 }].to_json,
+      )
+
+      response = client.all.submit
+
+      assert_equal [{ id: 1 }], response.body
+    end
+
+    test "raises an exception when a single argument block does not return only the body" do
+      stub_request(:post, "https://example.com/articles")
+      client = declare_client do
+        after_submit { |body| nil }
+
+        def create
+          post url: "https://example.com/articles"
+        end
+      end
+
+      assert_raises ActionClient::AfterSubmitError, /body/ do
+        client.create.submit
+      end
+    end
+  end
+end

--- a/test/integration_test_case.rb
+++ b/test/integration_test_case.rb
@@ -4,5 +4,23 @@ require "template_test_helpers"
 module ActionClient
   class IntegrationTestCase < ActiveSupport::TestCase
     include TemplateTestHelpers
+
+    def declare_client(controller_path = nil, &block)
+      Class.new(ActionClient::Base).tap do |client_class|
+        if controller_path.present?
+          client_class.class_eval <<~RUBY
+          def self.controller_path
+            #{controller_path.inspect}
+          end
+          RUBY
+        end
+
+        client_class.class_eval(&block)
+      end
+    end
+
+    setup do
+      ActionClient::Base.defaults = ActiveSupport::OrderedOptions.new
+    end
   end
 end


### PR DESCRIPTION
When submitting requests from an `ActionClient::Base` descendant, it can
be useful to modify the response's body before returning the response to
the caller.

As an example, consider instantiating [`OpenStruct`
instances][OpenStruct] from each response body by declaring an
`after_submit` hook:

```ruby
class ArticlesClient < ActionClient::Base
  after_submit do |status, headers, body|
    [status, headers, OpenStruct.new(body)]
  end
end
```

When declaring `after_submit` hooks, it's important to make sure that
the block returns a [`Rack`-compliant triplet][Rack-Response] of
`status`, `headers`, and `body`.

To specify a request-specific callback, pass a [block
argument][ruby-block] that accepts a `Rack` triplet.

For example, assuming that an `Article` model class exists and accepts
attributes as a `Hash`, consider constructing an instance from the
`body`:

```ruby
class ArticlesClient < ActionClient::Base
  default url: "https://example.com"

  def create(title:)
    @title = title

    post path: "/articles" do |status, headers, body|
      [status, headers, Article.new(body)]
    end
  end
end
```

Request-level blocks are executed _after_ class-level `after_submit`
blocks.

Transforming the response's `body`
---

When your callback is only interested in modifying the `body`, you can
declare it with a single block argument:

```ruby
class ArticlesClient < ActionClient::Base
  default url: "https://example.com"

  def create(title:)
    @title = title

    post path: "/articles" do |body|
      Article.new(body)
    end
  end
end
```

[OpenStruct]: https://ruby-doc.org/stdlib-2.7.1/libdoc/ostruct/rdoc/OpenStruct.html
[Rack-Response]: https://github.com/rack/rack/blob/master/SPEC.rdoc#label-Rack+applications
[ruby-block]: https://ruby-doc.org/core-2.7.1/doc/syntax/methods_rdoc.html#label-Block+Argument

Executing `after_submit` for a range of HTTP Status Codes
---

In some cases, applications might want to raise Errors based on a
response's [HTTP Status Code][HTTP-codes].

For example, when a response has a [422 HTTP Status][422], the server is
indicating that there were invalid parameters.

To map that to an application-specific error code, declare an
`after_submit` that passes a `with_status: 422` as a keyword argument:

```ruby
class ArticlesClient < ActionClient::Base
  after_submit with_status: 422 do |status, headers, body|
    raise MyApplication::InvalidDataError, body.fetch("error")
  end
end
```

In some cases, there are multiple HTTP Status codes that might map to a
similar concept. For example, a [401][] and [403][] might correspond to
similar concepts in your application, and you might want to handle them
the same way.

You can pass them to `after_submit with_status:` as either an
[`Array`][ruby-array] or a [`Range`][ruby-range]:

```ruby
class ArticlesClient < ActionClient::Base
  after_submit with_status: [401, 403] do |status, headers, body|
    raise MyApplication::SecurityError, body.fetch("error")
  end

  after_submit with_status: 401..403 do |status, headers, body|
    raise MyApplication::SecurityError, body.fetch("error")
  end
end
```

If the block is only concerned with the value of the `body`, declare the
block with a single argument:

```ruby
class ArticlesClient < ActionClient::Base
  after_submit with_status: 422 do |body|
    raise MyApplication::ArgumentError, body.fetch("error")
  end
end
```

When passing the [HTTP Status Code][HTTP-codes] singularly or as an
`Array`, `after_submit` will also accept a `Symbol` that corresponds to
the [name of the Status Code][status-code-name]:

```ruby
class ArticlesClient < ActionClient::Base
  after_submit with_status: :unprocessable_entity do |body|
    raise MyApplication::ArgumentError, body.fetch("error")
  end

  after_submit with_status: [:unauthorized, :forbidden] do |body|
    raise MyApplication::SecurityError, body.fetch("error")
  end
end
```

[HTTP-codes]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
[ruby-array]: https://ruby-doc.org/core-2.7.1/Array.html
[ruby-range]: https://ruby-doc.org/core-2.7.1/Range.html
[status-code-name]: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml

