### PR TITLE
Ensure descendants clone fresh defaults

### DIFF
--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -3,11 +3,15 @@ module ActionClient
     include AbstractController::Rendering
     include ActionView::Layouts
 
-    cattr_accessor :defaults,
+    class_attribute :defaults,
       instance_accessor: true,
       default: ActiveSupport::OrderedOptions.new
 
     class << self
+      def inherited(descendant)
+        descendant.defaults = defaults.dup
+      end
+
       def default(options)
         options.each do |key, value|
           defaults[key] = value

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -291,6 +291,33 @@ module ActionClient
         client.create(article: nil)
       end
     end
+
+    test "ensures each descendant gets its own copy of defaults" do
+      application_client = declare_client do
+        default url: "https://example.com"
+      end
+      articles_client = Class.new(application_client) do
+        default url: "https://example.com/articles"
+
+        def create
+          post
+        end
+      end
+
+      tags_client = Class.new(application_client) do
+        default url: "https://example.com/tags"
+
+        def create
+          post
+        end
+      end
+
+      articles_request = articles_client.create
+      tags_request = tags_client.create
+
+      assert_equal "https://example.com/articles", articles_request.url
+      assert_equal "https://example.com/tags", tags_request.url
+    end
   end
 
   class ResponsesTest < ClientTestCase


### PR DESCRIPTION
Prior to this commit, the `ActionClient::Base` class defined its
defaults using [`Module#mattr_accessor`][mattr_accessor], which
_ensures_ that descendants share the same instance as its accessors:

> If a subclass changes the value then that would also change the value
> for parent class. Similarly if parent class changes the value then
> that would change the value of subclasses too.

This commit replaces that with a call to
[`Class#class_attribute`][class_attribute], which _ensures_ that
descendants can set a value without modifying their parent's reference:

> Subclasses can change their own value and it will not impact parent
> class.

To ensure that each descendant from `ActionClient::Base` has its own
instance of `defaults`, clone a fresh `defaults` instance from its
parent by that behavior in the `Class#inherited` life cycle hook.

[class_attribute]: https://api.rubyonrails.org/classes/Class.html#method-i-class_attribute
[cattr_accessor]: https://api.rubyonrails.org/classes/Module.html#method-i-cattr_accessor
[mattr_accessor]: https://api.rubyonrails.org/classes/Module.html#method-i-mattr_accessor
[inherited]: https://ruby-doc.org/core-2.7.1/Class.html#method-i-inheritedo