### PR TITLE
Improve Query Parameter Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,35 @@ instances][nokogiri-document] by [`Nokogiri::XML`][nokogiri-xml].
 [nokogiri-xml]: https://nokogiri.org/rdoc/Nokogiri.html#XML-class_method
 [nokogiri-document]: https://nokogiri.org/rdoc/Nokogiri/XML/Document.html
 
+### Query Parameters
+
+To set a request's query parameters, pass them a `Hash` under the `query:`
+option:
+
+```ruby
+class ArticlesClient < ActionClient::Base
+  def all(search_term:)
+    get url: "https://examples.com/articles", query: { q: search_term }
+  end
+end
+```
+
+You can also pass query parameters directly as part of the `url:` or `path:`
+option:
+
+```ruby
+class ArticlesClient < ActionClient::Base
+  default url: "https://examples.com"
+
+  def all(search_term:, **query_parameters)
+    get path: "/articles?q={search_term}", query: query_parameters
+  end
+end
+```
+
+When a key-value pair exists in both the `path:` (or `url:`) option and `query:`
+option, the value present in the URL will be overridden by the `query:` value.
+
 ### Configuration
 
 Descendants of `ActionClient::Base` can specify some defaults:

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -280,6 +280,83 @@ module ActionClient
       assert_equal "application/xml", request.headers["Content-Type"]
     end
 
+    test "joins the path: to the default url:" do
+      client = declare_client do
+        default url: "https://example.com"
+
+        def all
+          get path: "articles"
+        end
+      end
+
+      request = client.all
+
+      assert_equal "https://example.com/articles", request.url
+    end
+
+    test "supports query parameters in the url: option" do
+      client = declare_client do
+        def all
+          get url: "https://example.com/articles?q=all"
+        end
+      end
+
+      request = client.all
+
+      assert_equal "https://example.com/articles?q=all", request.url
+    end
+
+    test "supports query parameters in the path: option" do
+      client = declare_client do
+        default url: "https://example.com"
+
+        def all
+          get path: "articles?q=all"
+        end
+      end
+
+      request = client.all
+
+      assert_equal "https://example.com/articles?q=all", request.url
+    end
+
+    test "supports query in the query: option" do
+      client = declare_client do
+        def all
+          get url: "https://example.com/articles", query: { q: :all }
+        end
+      end
+
+      request = client.all
+
+      assert_equal "https://example.com/articles?q=all", request.url
+    end
+
+    test "merges URL query parameters with those passed under the query: option" do
+      client = declare_client do
+        def all(search_term:, **query_parameters)
+          get url: "https://example.com/articles?q=#{search_term}", query: query_parameters
+        end
+      end
+
+      request = client.all(search_term: "foo", page: 1)
+
+      assert_equal "https://example.com/articles?page=1&q=foo", request.url
+    end
+
+
+    test "raises an ArgumentError if path: provided without default url:" do
+      client = declare_client do
+        def create(article:)
+          post path: "ignored"
+        end
+      end
+
+      assert_raises ArgumentError, /path|url/ do
+        client.create(article: nil)
+      end
+    end
+
     test "raises an ArgumentError when both url: and path: are provided" do
       client = declare_client do
         def create(article:)


### PR DESCRIPTION
To set a request's query parameters, pass them a `Hash` under the
`query:` option:

```ruby
class ArticlesClient < ActionClient::Base
  def all(search_term:)
    get url: "https://examples.com/articles", query: { q: search_term }
  end
end
```

You can also pass query parameters directly as part of the `url:` or
`path:` option:

```ruby
class ArticlesClient < ActionClient::Base
  default url: "https://examples.com"

  def all(search_term:, **query_parameters)
    get(
      path: "https://examples.com/articles?q={search_term}",
      query: query_parameters,
    )
  end
end
```

When a key-value pair exists in both the `path:` (or `url:`) option and
`query:` option, the value present in the URL will be overridden by the
`query:` value.