### PR TITLE
Integrate with `Rails.application.config_for`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Integrate with Rails' `config_for` by reading configuration files declared
+  in `config/clients` named to match the client name. For example,
+  `ArticlesClient` will read from `config/clients/articles.yml`.
+  (added by [@seanpdoyle][])
+
 - The `after_submit` callbacks, along with request-level block versions, and the
   specialized `with_status:` version (added by [@seanpdoyle][])
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,41 @@ Default values can be overridden on a request-by-request basis.
 When a default `url:` key is specified, a request's full URL will be built by
 joining the base `default url: ...` value with the request's `path:` option.
 
+In this example, `ArticlesClient.configuration` will read directly from the
+environment-aware `config/clients/articles.yml` file.
+
+Consider the following configuration:
+
+```yaml
+# config/clients/articles.yml
+default: &default
+  url: "https://staging.example.com"
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default
+  url: "https://example.com"
+```
+
+Then from the client class, read those values directly from `configuration`:
+
+```ruby
+class ArticlesClient < ActionClient::Base
+  default url: configuration.url
+end
+```
+
+When a matching configuration file does not exist,
+`ActionClient::Base.configuration` returns an empty instance of
+[`ActiveSupport::OrderedOptions`][OrderedOptions].
+
+[OrderedOptions]: https://api.rubyonrails.org/classes/ActiveSupport/OrderedOptions.html
+
 ### Declaring `after_submit` callbacks
 
 When submitting requests from an `ActionClient::Base` descendant, it can be
@@ -310,7 +345,6 @@ class ArticlesClient < ActionClient::Base
   end
 end
 ```
-
 
 [HTTP-codes]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
 [401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401

--- a/lib/action_client/engine.rb
+++ b/lib/action_client/engine.rb
@@ -2,6 +2,7 @@ module ActionClient
   class Engine < ::Rails::Engine
     initializer "action_client.dependencies" do |app|
       ActionClient::Base.append_view_path app.paths["app/views"]
+      ActionClient::Base.config_path = Pathname(app.paths["config"].first)
     end
 
     initializer "action_client.middleware" do

--- a/test/integration/action_client/configuration_test.rb
+++ b/test/integration/action_client/configuration_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+require "integration_test_case"
+
+module ActionClient
+  class ConfigurationTestCase < ActionClient::IntegrationTestCase
+    test "can read configuration values from a file" do
+      declare_config "clients/articles.yml", <<~YAML
+      test:
+        url: "https://example.com"
+      YAML
+      client = declare_client "articles_client" do
+        default url: configuration.url
+
+        def all
+          get path: "articles"
+        end
+      end
+
+      request = client.all
+
+      assert_equal "https://example.com/articles", request.url
+    end
+
+    test "defaults to an empty configuration when a file is not present" do
+      client = declare_client "articles_client" do
+        default url: configuration.url || "https://example.com"
+
+        def all
+          get path: "articles"
+        end
+      end
+
+      request = client.all
+
+      assert_equal "https://example.com/articles", request.url
+    end
+  end
+end

--- a/test/template_test_helpers.rb
+++ b/test/template_test_helpers.rb
@@ -2,11 +2,24 @@ module TemplateTestHelpers
   def around(&block)
     Dir.mktmpdir do |temporary_directory|
       @partial_path = Pathname(temporary_directory).join("app", "views")
+      @config_path = Pathname(temporary_directory).join("config")
 
       with_view_path_prefixes(@partial_path) do
-        block.call
+        with_config_path(@config_path) do
+          block.call
+        end
       end
     end
+  end
+
+  def with_config_path(temporary_directory, &block)
+    config_path = ActionClient::Base.config_path
+
+    ActionClient::Base.config_path = temporary_directory
+
+    block.call
+  ensure
+    ActionClient::Base.config_path = config_path
   end
 
   def with_view_path_prefixes(temporary_view_directory, &block)
@@ -17,6 +30,14 @@ module TemplateTestHelpers
     block.call
   ensure
     ActionClient::Base.view_paths = view_paths
+  end
+
+  def declare_config(partial_path, body)
+    @config_path.join(partial_path).tap do |file|
+      file.dirname.mkpath
+
+      file.write(body)
+    end
   end
 
   def declare_template(partial_path, body)


### PR DESCRIPTION
[Implements #9][#9]

In this example, `ArticlesClient.configuration` will read directly from the
environment-aware `config/clients/articles.yml` file.

Consider the following configuration:

```yaml
default: &default
  url: "https://staging.example.com"

development:
  <<: *default

test:
  <<: *default

production:
  <<: *default
  url: "https://example.com"
```

Then from the client class, read those values directly from `configuration`:

```ruby
class ArticlesClient < ActionClient::Base
  default url: configuration.url
end
```

When a matching configuration file does not exist,
`ActionClient::Base.configuration` returns an empty instance of
[`ActiveSupport::OrderedOptions`][OrderedOptions].

[OrderedOptions]: https://api.rubyonrails.org/classes/ActiveSupport/OrderedOptions.html
[#9]: https://github.com/thoughtbot/action_client/issues/9