### PR TITLE
Replace Rack triplets with `Rack::Response`

### DIFF
--- a/lib/action_client/response.rb
+++ b/lib/action_client/response.rb
@@ -1,0 +1,9 @@
+module ActionClient
+  class Response < Rack::Response
+    def initialize(body = nil, *arguments)
+      super
+
+      self.body = body
+    end
+  end
+end

--- a/lib/action_client/submittable_request.rb
+++ b/lib/action_client/submittable_request.rb
@@ -8,7 +8,9 @@ module ActionClient
     def submit
       app = @stack.build(ActionClient::Applications::Net::HttpClient.new)
 
-      app.call(env)
+      status, headers, body = app.call(env)
+
+      ActionClient::Response.new(body, status, headers)
     end
   end
 end

--- a/test/action_client/response_test.rb
+++ b/test/action_client/response_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+module ActionClient
+  class ResponseTest < ActiveSupport::TestCase
+    test ".[] inherits behavior of Rack::Response" do
+      response = ActionClient::Response[
+        "200",
+        {"Accept" => "text/plain"},
+        "body string",
+      ]
+
+      status, headers, body = *response
+
+      assert_equal 200, status
+      assert_equal "text/plain", headers["Accept"]
+      assert_equal "body string", body
+    end
+
+    test "#initialize sets a body String, without buffering it" do
+      response = ActionClient::Response.new("body string")
+
+      status, headers, body = *response
+
+      assert_equal 200, status
+      assert_equal "body string", body
+    end
+
+    test "#initialize sets a body Hash, without buffering it" do
+      response = ActionClient::Response.new({response: "body"})
+
+      status, headers, body = *response
+
+      assert_equal 200, status
+      assert_equal "body", body.fetch(:response)
+    end
+
+    test "#initialize sets a body Array, without buffering it" do
+      response = ActionClient::Response.new([{response: "body"}])
+
+      status, headers, body = *response
+
+      assert_equal 200, status
+      assert_equal [{response: "body"}], body
+    end
+  end
+end


### PR DESCRIPTION
Replace Rack triplets with `ActionClient::Response`
===

Introduce the `ActionClient::Response` class as a minimal wrapper around
[`Rack::Response`][Rack::Response].

After some brief application-integration experiments, we've found
anecdotal evidence that suggests that most Real World :tm: requests are
unconcerned with the HTTP Status Code or Headers.

This will be especially true as we add more and more HTTP Status
focussed features (like those implemented in [#3][] and [#5][]).

If consumers would prefer to deal with the [Rack status-headers-body
triplet][rack-triplet] directly, they can coerce the
[`Rack::Response`][Rack::Response] into an `Array` for multiple
assignment by splatting (`*`) the return value directly:,

```ruby
request = ArticlesClient.create(title: "Hello, World")

status, headers, body = *request.submit
```

Rack::Response
---

Returning a `Rack::Response` instance was preferable to
`ActionDispatch::Response` instances (or instances of a bespoke
`Response` class), since `ActionDispatch::Response` [forces the `body`
into an instance of
`ActionDispatch::Response::RackBody`][rack_response].

Once wrapped in an `ActionDispatch::Response::RackBody`, consumers of
`ActionClient::Base` instances would be responsible for re-constructing
the body from its deconstructed portions.

A similar issue exists for `Rack::Response` instances, since they
[ensure that `body` values that respond to `#to_str` are
iterable][to_str]. Since `Rack::Response` provides a means of setting
the body directly, the `ActionClient::Response` subclass does so in its
constructor.

[#3]: https://github.com/thoughtbot/action_client/pull/3
[#5]: https://github.com/thoughtbot/action_client/pull/5
[Rack::Response]: https://www.rubydoc.info/gems/rack/Rack/Response
[rack-triplet]: https://github.com/rack/rack/blob/master/SPEC.rdoc#the-response-
[to_str]: https://github.com/rack/rack/blob/a5e80f01947954af76b14c1d1fdd8e79dd8337f3/lib/rack/response.rb#L55-L58
[rack_response]: https://github.com/rails/rails/blob/34991a6ae2fc68347c01ea7382fa89004159e019/actionpack/lib/action_dispatch/http/response.rb#L529-L534

