### PR TITLE
Ensure that `ActionClient::Base` is abstract

### DIFF
--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -3,6 +3,8 @@ module ActionClient
     include AbstractController::Rendering
     include ActionView::Layouts
 
+    abstract!
+
     class_attribute :defaults,
       instance_accessor: true,
       default: ActiveSupport::OrderedOptions.new

--- a/test/controllers/action_client/clients_controller_test.rb
+++ b/test/controllers/action_client/clients_controller_test.rb
@@ -39,10 +39,12 @@ module ActionClient
     test "#show includes links to available previewed methods" do
       get client_path(ArticlesClientPreview.preview_name)
 
-      assert_select(
-        %(a[href*="#{client_preview_path(ArticlesClientPreview.preview_name, "create")}"]),
-        text: "create",
-      )
+      assert_select "li", count: 1 do
+        assert_select(
+          %(a[href*="#{client_preview_path(ArticlesClientPreview.preview_name, "create")}"]),
+          text: "create",
+        )
+      end
     end
   end
 end

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -24,6 +24,22 @@ module ActionClient
     end
   end
 
+  class ActionMethodsTest < ClientTestCase
+    test "only exposes declared requests as action_methods" do
+      client = declare_client do
+        def create
+        end
+
+        def destroy
+        end
+      end
+
+      action_methods = client.action_methods.to_a
+
+      assert_equal ["create", "destroy"], action_methods
+    end
+  end
+
   class RequestsTest < ClientTestCase
     test "constructs a request that encodes the port" do
       client = declare_client do


### PR DESCRIPTION
Prior to this commit, any method declared on the `ActionClient::Base`
class (upwards of 36 methods) was made available to its descendants as
[`action_methods`][action_methods].

Typical Rails constrollers start with 7 action methods (`new`, `create`,
`show`, `index`, `edit`, `update`, `destroy`), omitting most methods
implemented by `ActionController::Base`.

To limit the descendant client lists in available to
`ActionClient::Preview` instances, declare that `ActionClient::Base` is
an "abstract" controller, by declaring the [`abstract!` class
method][abstract!], so that any public method declared by descendant
classes is considered an action.

[action_methods]: https://api.rubyonrails.org/classes/AbstractController/Base.html#method-c-action_methods
[abstract!]: https://api.rubyonrails.org/classes/AbstractController/Base.html#method-c-abstract-21