### PR TITLE
Sort ActionMethod names in test

### DIFF
--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -36,7 +36,7 @@ module ActionClient
 
       action_methods = client.action_methods.to_a
 
-      assert_equal ["create", "destroy"], action_methods
+      assert_equal ["create", "destroy"], action_methods.sort
     end
   end
 


### PR DESCRIPTION
Evidently, the `Array` built by `Set#to_a` is not predictable.

To resolve that, call [`Enumerable#sort`][sort].

[sort]: https://ruby-doc.org/core-2.7.1/Enumerable.html#method-i-sort
[failing test]: https://github.com/thoughtbot/action_client/pull/3/checks?check_run_id=768266571