### PR TITLE
Ensure Client classes respond_to? actions

### DIFF
--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -49,6 +49,10 @@ module ActionClient
         controller_path.gsub("_client", "")
       end
 
+      def respond_to?(method, *arguments)
+        action_methods.include?(method.to_s) || super
+      end
+
       def method_missing(method_name, *arguments)
         if action_methods.include?(method_name.to_s)
           self.new(middleware).process(method_name, *arguments)

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -7,6 +7,19 @@ module ActionClient
   end
 
   class ActionMethodsTest < ClientTestCase
+    test "the Base class responds to action methods" do
+      client = declare_client do
+        def create
+        end
+      end
+
+      responds_to_create = client.respond_to?(:create)
+      responds_to_destroy = client.respond_to?(:destroy)
+
+      assert_equal true, responds_to_create
+      assert_equal false, responds_to_destroy
+    end
+
     test "only exposes declared requests as action_methods" do
       client = declare_client do
         def create


### PR DESCRIPTION
In order to integrate with strict stubbing tools like [RSpec's Partial
Test Doubles][partial-test-doubles], descendants of `ActionClient::Base`
must respond to the action methods their instances declare.

This commit adds test coverage to ensure that
`ActionClient::Base.respond_to?` returns `true` for action methods.

[partial-test-doubles]: https://relishapp.com/rspec/rspec-mocks/docs/basics/partial-test-doubles