### PR TITLE
Add test coverage for HttpStatusFilter

### DIFF
--- a/lib/action_client/http_status_filter.rb
+++ b/lib/action_client/http_status_filter.rb
@@ -1,15 +1,30 @@
 module ActionClient
   class HttpStatusFilter
-    delegate_missing_to :status_codes
-
     def initialize(http_status)
-      @status_codes = Array(http_status || (100..599)).map do |status|
-        Rack::Utils.status_code(status)
-      end
+      @http_status = http_status
+    end
+
+    def include?(matching_status)
+      status_codes.include? to_code(matching_status)
     end
 
     private
 
-    attr_reader :status_codes
+    attr_reader :http_status
+
+    def status_codes
+      case http_status
+      when nil
+        100..599
+      when Range
+        http_status
+      else
+        Array(http_status).map { |status| to_code(status) }
+      end
+    end
+
+    def to_code(status)
+      Rack::Utils.status_code(status)
+    end
   end
 end

--- a/test/action_client/http_status_filter_test.rb
+++ b/test/action_client/http_status_filter_test.rb
@@ -1,0 +1,104 @@
+require "test_helper"
+
+module ActionClient
+  class HttpStatusFilterTest < ActiveSupport::TestCase
+    test "#include? returns true when the status is nil" do
+      filter = HttpStatusFilter.new(nil)
+      status_codes = 100..599
+
+      included = status_codes.all? { |status_code| filter.include?(status_code) }
+
+      assert_equal true, included
+    end
+
+    test "#include? delegates to a Range" do
+      filter = HttpStatusFilter.new(100..599)
+
+      included = filter.include?(101)
+      excluded = filter.include?(600)
+
+      assert_equal true, included
+      assert_equal false, excluded
+    end
+
+    test "#include? delegates to an Endless Range" do
+      filter = HttpStatusFilter.new(100..)
+
+      included = filter.include?(101)
+      excluded = filter.include?(99)
+
+      assert_equal true, included
+      assert_equal false, excluded
+    end
+
+    test "#include? covers an Array of status codes" do
+      filter = HttpStatusFilter.new([401, 403])
+
+      included = filter.include?(401)
+      excluded = filter.include?(422)
+
+      assert_equal true, included
+      assert_equal false, excluded
+    end
+
+    test "#include? covers an Array of status names" do
+      filter = HttpStatusFilter.new([:unauthorized, :forbidden])
+
+      included = filter.include?(401)
+      excluded = filter.include?(422)
+
+      assert_equal true, included
+      assert_equal false, excluded
+    end
+
+    test "#include? covers an Array of mixed statuses" do
+      filter = HttpStatusFilter.new([401, :forbidden])
+
+      included = filter.include?(401)
+      excluded = filter.include?(422)
+
+      assert_equal true, included
+      assert_equal false, excluded
+    end
+
+    test "#include? covers a single item status name" do
+      filter = HttpStatusFilter.new(:unauthorized)
+
+      included = filter.include?(401)
+      excluded = filter.include?(422)
+
+      assert_equal true, included
+      assert_equal false, excluded
+    end
+
+    test "#include? covers a single item status code" do
+      filter = HttpStatusFilter.new(401)
+
+      included = filter.include?(401)
+      excluded = filter.include?(422)
+
+      assert_equal true, included
+      assert_equal false, excluded
+    end
+
+    test "#include? matches two status names" do
+      filter = HttpStatusFilter.new(:unauthorized)
+
+      included = filter.include?(:unauthorized)
+      excluded = filter.include?(:unprocessable_entity)
+
+      assert_equal true, included
+      assert_equal false, excluded
+    end
+
+    test "#include? transforms the argument into a status code" do
+      filter = HttpStatusFilter.new(401)
+
+      included = filter.include?(:unauthorized)
+      excluded = filter.include?(:unprocessable_entity)
+
+      assert_equal true, included
+      assert_equal false, excluded
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, any calls to `after_submit` with an [Endless
Range][endless] would result in an error, since the naive implementation
would coerce all values to an `Array`.

This commit adds test coverage to ensure that existing behavior remains
intact, and then extends the `HttpStatusFilter` to support Endless
Ranges.

[endless]: https://ruby-doc.org/core-2.7.1/Range.html#class-Range-label-Beginless-2FEndless+Ranges