### PR TITLE
Configure Previews routes and their directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Configure whether or not to mount Preview routes along with the directory
+  they're loaded from.
+  (added by [@seanpdoyle][])
+
 - Add support for extending how the Response middleware parses body strings
   (added by [@seanpdoyle][])
 

--- a/README.md
+++ b/README.md
@@ -517,6 +517,22 @@ command][curl].
 [action_mailer_previews]: https://guides.rubyonrails.org/action_mailer_basics.html#previewing-emails
 [curl]: https://curl.haxx.se/
 
+### Configuring Previews
+
+By default, Preview routes are available in all environments except for
+`production`, and can be changed by setting
+`config.action_client.enable_previews`.
+
+By default, Preview declarations are loaded from `test/clients/previews`, and
+can be changed by setting `config.action_client.previews_path`.
+
+```ruby
+# config/application.rb
+
+config.action_client.enable_previews = true
+config.action_client.previews_path = "spec/previews/clients"
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/app/views/action_client/previews/show.html.erb
+++ b/app/views/action_client/previews/show.html.erb
@@ -10,13 +10,17 @@
   cURL
 </h2>
 
-<pre>
+<pre id="curl">
 curl \
   --request <%= preview.request.request_method %> \
   <% ActionClient::Utils.headers_to_hash(preview.request.headers).each do |key, value| %>
- --header "<%= key %>: <%= value %>" \
+  --header "<%= key %>: <%= value %>" \
   <% end %>
-  --data '<%= preview.request.body.read.strip %>' \
+<% preview.request.body.read.strip.tap do |data| %>
+  <% if data.present? %>
+  --data '<%= data %>' \
+  <% end %>
+<% end %>
   <%= preview.request.original_url %>
 </pre>
 
@@ -38,11 +42,11 @@ curl \
   <% end %>
 </pre>
 
+
+<% if preview.request.body.any? %>
 <h2>
   Body
 </h2>
-
-<% if preview.request.body.any? %>
   <pre id="body"><%=
     JSON.pretty_generate(JSON.parse(preview.request.body.read))
   %></pre>

--- a/lib/action_client/engine.rb
+++ b/lib/action_client/engine.rb
@@ -1,6 +1,9 @@
 module ActionClient
   class Engine < ::Rails::Engine
-    config.action_client = ActiveSupport::OrderedOptions.new
+    config.action_client = ActiveSupport::InheritableOptions.new(
+      enable_previews: !Rails.env.production?,
+      previews_path: "test/clients/previews"
+    )
 
     initializer "action_client.dependencies" do |app|
       ActionClient::Base.append_view_path app.paths["app/views"]
@@ -16,7 +19,9 @@ module ActionClient
     end
 
     initializer "action_client.routes" do |app|
-      unless Rails.env.production?
+      if config.action_client.enable_previews
+        ActionClient::Preview.previews_path = config.action_client.previews_path
+
         app.routes.prepend do
           mount ActionClient::Engine => "/rails/action_client", :as => :action_client_engine
         end

--- a/lib/action_client/preview.rb
+++ b/lib/action_client/preview.rb
@@ -32,7 +32,9 @@ module ActionClient
       end
 
       def action_methods
-        client_class.action_methods
+        client_class.action_methods.select do |action_name|
+          instance_methods.map(&:to_s).include?(action_name)
+        end
       end
 
       def to_param

--- a/lib/action_client/preview.rb
+++ b/lib/action_client/preview.rb
@@ -2,6 +2,10 @@ module ActionClient
   class Preview
     extend ActiveSupport::DescendantsTracker
 
+    class_attribute :previews_path,
+      instance_accessor: true,
+      default: "test/clients/previews"
+
     class << self
       def all
         if descendants.empty?
@@ -42,7 +46,7 @@ module ActionClient
       end
 
       def load_previews
-        Dir[Rails.root.join("test/clients/previews/**/*_preview.rb")].sort.each do |file|
+        Dir[Rails.root.join("#{previews_path}/**/*_preview.rb")].sort.each do |file|
           require_dependency(file)
         end
       end

--- a/test/controllers/action_client/clients_controller_test.rb
+++ b/test/controllers/action_client/clients_controller_test.rb
@@ -7,6 +7,9 @@ module ActionClient
     class ArticlesClient < ActionClient::Base
       def create
       end
+
+      def no_preview
+      end
     end
 
     class ArticlesClientPreview < ActionClient::Preview
@@ -36,15 +39,16 @@ module ActionClient
       )
     end
 
-    test "#show includes links to available previewed methods" do
+    test "#show includes links to available preview methods" do
+      create_path = client_preview_path(ArticlesClientPreview.preview_name, "create")
+      no_preview_path = client_preview_path(ArticlesClientPreview.preview_name, "no_preview")
+
       get client_path(ArticlesClientPreview.preview_name)
 
       assert_select "li", count: 1 do
-        assert_select(
-          %(a[href*="#{client_preview_path(ArticlesClientPreview.preview_name, "create")}"]),
-          text: "create"
-        )
+        assert_select(%(a[href*="#{create_path}"]), text: "create")
       end
+      assert_select(%(a[href*="#{no_preview_path}"]), text: "no_preview", count: 0)
     end
   end
 end

--- a/test/controllers/action_client/previews_controller_test.rb
+++ b/test/controllers/action_client/previews_controller_test.rb
@@ -10,11 +10,19 @@ module ActionClient
       def create(title:)
         post url: "https://example.com/articles", locals: {title: title}
       end
+
+      def all
+        get url: "https://example.com/articles"
+      end
     end
 
     class ArticlesClientPreview < ActionClient::Preview
       def create
         ArticleClient.create(title: "Hello, World")
+      end
+
+      def all
+        ArticleClient.all
       end
     end
 
@@ -37,6 +45,12 @@ module ActionClient
       get client_preview_path(ArticlesClientPreview.preview_name, "create")
 
       assert_select "#body", count: 0
+    end
+
+    test "action_client/previews omits --data from cURL command when template is not declared" do
+      get client_preview_path(ArticlesClientPreview.preview_name, "all")
+
+      assert_not_includes css_select("#curl").text, "--data"
     end
   end
 end


### PR DESCRIPTION
Configure Previews routes and their directory
===

By default, Preview routes are available in all environments except for
`production`, and can be changed by setting
`config.action_client.enable_previews`.

By default, Preview declarations are loaded from
`test/clients/previews`, and can be changed by setting
`config.action_client.previews_path`.

```ruby

config.action_client.enable_previews = true
config.action_client.previews_path = "spec/clients/previews"
```

Trim the list of Client Action previews
===

This commit ensures that _only_ Client actions that have corresponding
Preview actions will be accessible from the `/rails/action_client`
routes.

