### PR TITLE
Infer Headers based on URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Determine a request's missing `Accept` HTTP Header based on the URL path's
+  file extension (added by [@seanpdoyle][])
+
 - When determining how to parse the response, fall back to the request's
   `Accept` header when the response's `Content-Type` header is missing
   (added by [@seanpdoyle][])

--- a/README.md
+++ b/README.md
@@ -68,18 +68,23 @@ class ArticlesClient < ActionClient::Base
 end
 ```
 
-By default, `ActionClient` will deduce the request's [`Content-Type:
-application/json` HTTP header][mdn-content-type] based on the format of the
-action's template. In this case, since we've declared `.json.erb`, the
-`Content-Type` will be set to `application/json`. The same would be true for a
-template named `create.json.jbuilder`.
+By default, `ActionClient` will deduce the request's
+[`Content-Type`][mdn-content-type] and [`Accept`][mdn-accept] HTTP headers based
+on the format of the action's template. In this example's case, since we've
+declared `.json.erb`, the `Content-Type` will be set to `application/json`. The
+same would be true for a template named `create.json.jbuilder`.
 
 If we were to declare the template as `create.xml.erb` or `create.xml.builder`,
 the `Content-Type` header would be set to `application/xml`.
 
+For requests that have not explicitly set the `Accept` header and cannot infer
+it from the body's template format, a URL with a file extension will be used to
+determine the [`Accept` header][mdn-accept].
+
 [mdn-post]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
 [naming-actions]: https://guides.rubyonrails.org/action_controller_overview.html#methods-and-actions
 [mdn-content-type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+[mdn-accept]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
 
 ### Responses
 

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -126,6 +126,9 @@ module ActionClient
         body = ""
       end
 
+      file_extension = File.extname(uri.path).delete_prefix(".")
+      accept = Mime[file_extension].to_s
+
       query_parameters = Rack::Utils.parse_query(uri.query).merge(query)
 
       payload = CGI.unescapeHTML(body.to_s)
@@ -140,7 +143,7 @@ module ActionClient
       )
 
       headers.with_defaults(
-        "Accept" => content_type,
+        "Accept" => [accept, content_type].detect(&:present?),
         Rack::CONTENT_TYPE => content_type
       ).each do |key, value|
         request.headers[key] = value

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -374,6 +374,18 @@ module ActionClient
       assert_equal "https://example.com/articles?page=1&q=foo", request.url
     end
 
+    test "resolves the Accept header from the URL extension" do
+      client = declare_client {
+        def all
+          get url: "https://example.com/articles.json"
+        end
+      }
+
+      request = client.all
+
+      assert_equal "application/json", request.headers["Accept"]
+    end
+
     test "raises an ArgumentError if path: provided without default url:" do
       client = declare_client {
         def create(article:)


### PR DESCRIPTION
For requests that have not explicitly set the `Content-Type` header and
cannot infer it from the body's template format, a URL with a file
extension will be used to determine the [`Content-Type`][content-type]
and [`Accept`][accept] headers.

For example, client actions declaring `GET` requests won't have a
request body, so determining their `Content-Type` from the URL can be
helpful.

[content-type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
[accept]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept