### PR TITLE
Merge `default headers: {}` into inherited values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Merge descendant `default headers: {}` declarations into inherited values
+  (added by [@seanpdoyle][])
+
 - Determine a request's missing `Accept` HTTP Header based on the URL path's
   file extension (added by [@seanpdoyle][])
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,29 @@ class ArticlesClient < ActionClient::Base
 end
 ```
 
+When specifying default `headers:` values, descendant key-value pairs will
+override inherited key-value pairs. Consider the following inheritance
+hierarchy:
+
+```ruby
+class ApplicationClient < ActionClient::Base
+  default headers: {
+    "X-Special": "abc123",
+    "Content-Type": "text/plain",
+  }
+end
+
+class ArticlesClient < ApplicationClient
+  default headers: {
+    "Content-Type": "application/json"
+  }
+end
+```
+
+Requests made by the `ArticlesClient` will inherit the `X-Special` header from
+the `ApplicationClient`, and will override the `Content-Type` header to
+`application/json`, since it's declared in the descendant class.
+
 Default values can be overridden on a request-by-request basis.
 
 When a default `url:` key is specified, a request's full URL will be built by

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -39,7 +39,14 @@ module ActionClient
 
       def default(options)
         options.each do |key, value|
-          defaults[key] = value
+          default_value = defaults[key]
+
+          defaults[key] = case default_value
+          when Hash
+            default_value.with_indifferent_access.merge(value)
+          else
+            value
+          end
         end
       end
 

--- a/test/integration/action_client/configuration_test.rb
+++ b/test/integration/action_client/configuration_test.rb
@@ -3,6 +3,29 @@ require "integration_test_case"
 
 module ActionClient
   class ConfigurationTestCase < ActionClient::IntegrationTestCase
+    test "default headers will cascade down the inheritance hierarchy" do
+      application_client = declare_client("application_client") {
+        default headers: {
+          "X-Special": "abc123",
+          "Content-Type": "text/plain"
+        }
+      }
+      client = declare_client(inherits: application_client) {
+        default headers: {
+          "Content-Type": "application/json"
+        }
+
+        def all
+          get url: "https://example.com/articles"
+        end
+      }
+
+      request = client.all
+
+      assert_equal "abc123", request.headers["X-Special"]
+      assert_equal "application/json", request.headers["Content-Type"]
+    end
+
     test "can read configuration values from a file" do
       declare_config "clients/articles.yml", <<~YAML
         test:

--- a/test/integration_test_case.rb
+++ b/test/integration_test_case.rb
@@ -5,8 +5,8 @@ module ActionClient
   class IntegrationTestCase < ActiveSupport::TestCase
     include TemplateTestHelpers
 
-    def declare_client(controller_path = nil, &block)
-      Class.new(ActionClient::Base).tap do |client_class|
+    def declare_client(controller_path = nil, inherits: ActionClient::Base, &block)
+      Class.new(inherits).tap do |client_class|
         if controller_path.present?
           client_class.class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def self.controller_path


### PR DESCRIPTION
When specifying default `headers:` values, descendant key-value pairs
will override inherited key-value pairs. Consider the following
inheritance hierarchy:

```ruby
class ApplicationClient < ActionClient::Base
  default headers: {
    "X-Special": "abc123",
    "Content-Type": "text/plain",
  }
end

class ArticlesClient < ApplicationClient
  default headers: {
    "Content-Type": "application/json"
  }
end
```

Requests made by the `ArticlesClient` will inherit the `X-Special`
header from the `ApplicationClient`, and will override the
`Content-Type` header to `application/json`, since it's declared in the
descendant class.