### PR TITLE
Infer missing `Content-Type` during Response Parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- When determining how to parse the response, fall back to the request's
+  `Accept` header when the response's `Content-Type` header is missing
+  (added by [@seanpdoyle][])
+
 - Add support for inferring `Content-Type` based on the extension of raw
   templates (e.g. `articles_client/create.json`) (added by [@seanpdoyle[]])
 

--- a/lib/action_client/middleware/response_parser.rb
+++ b/lib/action_client/middleware/response_parser.rb
@@ -6,9 +6,13 @@ module ActionClient
       end
 
       def call(env)
+        request = ActionDispatch::Request.new(env)
         status, headers, body_proxy = @app.call(env)
         body = body_proxy.each(&:yield_self).sum
-        content_type = headers[Rack::CONTENT_TYPE].to_s
+        content_type = headers.fetch(
+          Rack::CONTENT_TYPE,
+          request.headers["Accept"]
+        ).to_s
 
         if body.present?
           if content_type.starts_with?("application/json")

--- a/test/action_client/middleware/response_parser_test.rb
+++ b/test/action_client/middleware/response_parser_test.rb
@@ -3,6 +3,19 @@ require "test_helper"
 module ActionClient
   module Middleware
     class ResponseParserTest < ActiveSupport::TestCase
+      test "#call infers missing Content-Type based on the request's Accept header" do
+        payload = %({"response": true})
+        app = ->(env) { [200, {}, env[Rack::RACK_INPUT]] }
+        middleware = ActionClient::Middleware::ResponseParser.new(app)
+
+        *, body = middleware.call({
+          "HTTP_ACCEPT" => "application/json",
+          Rack::RACK_INPUT => payload.lines
+        })
+
+        assert_equal({"response" => true}, body)
+      end
+
       test "#call decodes application/json to JSON" do
         payload = %({"response": true})
         app = proc do |env|


### PR DESCRIPTION
When determining how to parse the response, fall back to the request's
`Accept` header when the response's `Content-Type` header is missing.