### PR TITLE
Extend after_submit to accept more options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for `only:` to execute `after_submit` hooks for a given set of
+  action names (added by [@seanpdoyle][])
+
 - Add support for `except_status:` to exclude `after_submit` execution for a
   given set of HTTP Status codes (added by [@seanpdoyle][])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for `except_status:` to exclude `after_submit` execution for a
+  given set of HTTP Status codes (added by [@seanpdoyle][])
+
 - Rename `with_status:` option for `after_submit` and `after_perform`
   declarations to `only_status:` (added by [@seanpdoyle][])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for `except:` to omit execution of `after_submit` hooks for a
+  given set of action names (added by [@seanpdoyle][])
+
 - Add support for `only:` to execute `after_submit` hooks for a given set of
   action names (added by [@seanpdoyle][])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Rename `with_status:` option for `after_submit` and `after_perform`
+  declarations to `only_status:` (added by [@seanpdoyle][])
+
 - Configure whether or not to mount Preview routes along with the directory
   they're loaded from.
   (added by [@seanpdoyle][])

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ To enqueued an `ActionClient::Base` descendant class' requests with a custom
 ```ruby
 # app/jobs/articles_client_job.rb
 class ArticlesClientJob < ActionClient::SubmissionJob
-  after_perform with_status: 500..599 do
+  after_perform only_status: 500..599 do
     status, headers, body = *response
 
     Rails.logger.info("Retrying ArticlesClient job with status: #{status}...")
@@ -247,7 +247,7 @@ end
 ```
 
 The `ActionClient::SubmissionJob` provides an extended version of
-[`ActiveJob::Base.after_perform`][after_perform] that accepts a `with_status:`
+[`ActiveJob::Base.after_perform`][after_perform] that accepts a `only_status:`
 option, to serve as a guard clause filter.
 
 [after_perform]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
@@ -451,11 +451,11 @@ For example, when a response has a [422 HTTP Status][422], the server is
 indicating that there were invalid parameters.
 
 To map that to an application-specific error code, declare an `after_submit`
-that passes a `with_status: 422` as a keyword argument:
+that passes a `only_status: 422` as a keyword argument:
 
 ```ruby
 class ArticlesClient < ActionClient::Base
-  after_submit with_status: 422 do |status, headers, body|
+  after_submit only_status: 422 do |status, headers, body|
     raise MyApplication::InvalidDataError, body.fetch("error")
   end
 end
@@ -465,16 +465,16 @@ In some cases, there are multiple HTTP Status codes that might map to a similar
 concept. For example, a [401][] and [403][] might correspond to similar concepts
 in your application, and you might want to handle them the same way.
 
-You can pass them to `after_submit with_status:` as either an
+You can pass them to `after_submit only_status:` as either an
 [`Array`][ruby-array] or a [`Range`][ruby-range]:
 
 ```ruby
 class ArticlesClient < ActionClient::Base
-  after_submit with_status: [401, 403] do |status, headers, body|
+  after_submit only_status: [401, 403] do |status, headers, body|
     raise MyApplication::SecurityError, body.fetch("error")
   end
 
-  after_submit with_status: 401..403 do |status, headers, body|
+  after_submit only_status: 401..403 do |status, headers, body|
     raise MyApplication::SecurityError, body.fetch("error")
   end
 end
@@ -485,7 +485,7 @@ with a single argument:
 
 ```ruby
 class ArticlesClient < ActionClient::Base
-  after_submit with_status: 422 do |body|
+  after_submit only_status: 422 do |body|
     raise MyApplication::ArgumentError, body.fetch("error")
   end
 end
@@ -497,11 +497,11 @@ Status Code][status-code-name]:
 
 ```ruby
 class ArticlesClient < ActionClient::Base
-  after_submit with_status: :unprocessable_entity do |body|
+  after_submit only_status: :unprocessable_entity do |body|
     raise MyApplication::ArgumentError, body.fetch("error")
   end
 
-  after_submit with_status: [:unauthorized, :forbidden] do |body|
+  after_submit only_status: [:unauthorized, :forbidden] do |body|
     raise MyApplication::SecurityError, body.fetch("error")
   end
 end

--- a/README.md
+++ b/README.md
@@ -507,6 +507,19 @@ class ArticlesClient < ActionClient::Base
 end
 ```
 
+### Excluding an `after_submit` for a range of HTTP Status Codes
+
+To _exclude_ responses that don't match a particular set of HTTP Status codes,
+declare the `after_submit` with `except_status:` instead:
+
+```ruby
+class ArticlesClient < ActionClient::Base
+  after_submit except_status: [:success, :created] do |body|
+    raise MyApplication::ArgumentError, body.fetch("error")
+  end
+end
+```
+
 [HTTP-codes]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
 [401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
 [403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403

--- a/README.md
+++ b/README.md
@@ -468,6 +468,28 @@ class ArticlesClient < ActionClient::Base
 end
 ```
 
+Similarly, to specify which actions an `after_submit` hook **should not**
+execute for, declare an `after_submit` that passes theirs names as the `except:`
+option:
+
+```ruby
+class ArticlesClient < ActionClient::Base
+  after_submit(except: [:all]) { |body| Article.new(body) }
+
+  def create
+    # ...
+  end
+
+  def update
+    # ...
+  end
+
+  def all
+    # ...
+  end
+end
+```
+
 ### Executing `after_submit` for a range of HTTP Status Codes
 
 In some cases, applications might want to raise Errors based on a response's

--- a/README.md
+++ b/README.md
@@ -442,6 +442,32 @@ end
 [Rack-Response]: https://github.com/rack/rack/blob/master/SPEC.rdoc#label-Rack+applications
 [ruby-block]: https://ruby-doc.org/core-2.7.1/doc/syntax/methods_rdoc.html#label-Block+Argument
 
+### Executing `after_submit` for a set of Requests
+
+In some cases, a `ActionClient::Base` descendant might want to execute an
+`after_submit` hook for a certain set of Request actions.
+
+To specify which actions an `after_submit` hook should execute for, declare an
+`after_submit` that passes theirs names as the `only:` option:
+
+```ruby
+class ArticlesClient < ActionClient::Base
+  after_submit(only: [:create, :update]) { |body| Article.new(body) }
+
+  def create
+    # ...
+  end
+
+  def update
+    # ...
+  end
+
+  def all
+    # ...
+  end
+end
+```
+
 ### Executing `after_submit` for a range of HTTP Status Codes
 
 In some cases, applications might want to raise Errors based on a response's

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -55,8 +55,8 @@ module ActionClient
         end
       end
 
-      def after_submit(method_name = nil, with_status: nil, &block)
-        http_status_filter = HttpStatusFilter.new(with_status)
+      def after_submit(method_name = nil, only_status: nil, &block)
+        http_status_filter = HttpStatusFilter.new(only_status)
 
         set_callback :submit, :after do
           if http_status_filter.include?(response.status)

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -55,7 +55,7 @@ module ActionClient
         end
       end
 
-      def after_submit(method_name = nil, only: nil, only_status: nil, except_status: nil, &block)
+      def after_submit(method_name = nil, only: nil, except: nil, only_status: nil, except_status: nil, &block)
         http_status_filter = if only_status.present?
           HttpStatusFilter.new(only_status)
         elsif except_status.present?
@@ -69,6 +69,12 @@ module ActionClient
         if only.present?
           filters[:if] = -> {
             Array(only).map(&:to_s).include?(action_name)
+          }
+        end
+
+        if except.present?
+          filters[:unless] = -> {
+            Array(except).map(&:to_s).include?(action_name)
           }
         end
 

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -56,6 +56,18 @@ module ActionClient
       end
 
       def after_submit(method_name = nil, only: nil, except: nil, only_status: nil, except_status: nil, &block)
+        if [only, except].all?(&:present?)
+          raise ArgumentError, "either pass only: or except:, not both"
+        end
+
+        if [only_status, except_status].all?(&:present?)
+          raise ArgumentError, "either pass only_status: or except_status:, not both"
+        end
+
+        if [method_name, block].all?(&:present?)
+          raise ArgumentError, "either pass method name or block, not both"
+        end
+
         http_status_filter = if only_status.present?
           HttpStatusFilter.new(only_status)
         elsif except_status.present?

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -55,8 +55,14 @@ module ActionClient
         end
       end
 
-      def after_submit(method_name = nil, only_status: nil, &block)
-        http_status_filter = HttpStatusFilter.new(only_status)
+      def after_submit(method_name = nil, only_status: nil, except_status: nil, &block)
+        http_status_filter = if only_status.present?
+          HttpStatusFilter.new(only_status)
+        elsif except_status.present?
+          HttpStatusFilter.new(except_status, inclusion: false)
+        else
+          HttpStatusFilter.new(nil)
+        end
 
         set_callback :submit, :after do
           if http_status_filter.include?(response.status)

--- a/lib/action_client/http_status_filter.rb
+++ b/lib/action_client/http_status_filter.rb
@@ -1,22 +1,29 @@
 module ActionClient
   class HttpStatusFilter
-    def initialize(http_status)
+    def initialize(http_status, inclusion: true)
       @http_status = http_status
+      @inclusion = inclusion
     end
 
     def include?(matching_status)
       code = to_code(matching_status)
 
-      if status_codes.respond_to?(:cover?)
+      included = if status_codes.respond_to?(:cover?)
         status_codes.cover? code
       else
         status_codes.include? code
+      end
+
+      if inclusion
+        included
+      else
+        !included
       end
     end
 
     private
 
-    attr_reader :http_status
+    attr_reader :http_status, :inclusion
 
     def status_codes
       case http_status

--- a/lib/action_client/submission_job.rb
+++ b/lib/action_client/submission_job.rb
@@ -2,10 +2,10 @@ module ActionClient
   class SubmissionJob < ActiveJob::Base
     attr_reader :response
 
-    def self.after_perform(with_status: nil, **options, &block)
-      if with_status.present?
+    def self.after_perform(only_status: nil, **options, &block)
+      if only_status.present?
         filter = proc do
-          HttpStatusFilter.new(with_status).include?(response.status)
+          HttpStatusFilter.new(only_status).include?(response.status)
         end
 
         super(if: filter, **options, &block)

--- a/test/integration/action_client/active_job_test.rb
+++ b/test/integration/action_client/active_job_test.rb
@@ -48,7 +48,7 @@ module ActionClient
             status: 500
           ).times(1)
           .then.to_return(status: 200)
-        MetricsClientJob.after_perform(with_status: 400..599) do
+        MetricsClientJob.after_perform(only_status: 400..599) do
           status, headers, body = *response
           retry_job
         end

--- a/test/integration/action_client/callbacks_test.rb
+++ b/test/integration/action_client/callbacks_test.rb
@@ -69,6 +69,25 @@ module ActionClient
       assert_raises(CallbackError) { client.create.submit }
     end
 
+    test "executes methods specified in an after_submit callback when not matching the status" do
+      stub_request(:post, "https://example.com/articles").and_return(
+        status: 422
+      )
+      client = declare_client {
+        after_submit :raise_error, except_status: 200
+
+        def create
+          post url: "https://example.com/articles"
+        end
+
+        private def raise_error
+          raise CallbackError
+        end
+      }
+
+      assert_raises(CallbackError) { client.create.submit }
+    end
+
     test "after_submit executes on the body when passed a single argument" do
       stub_request(:post, "https://example.com/articles").and_return(
         body: %({"status": "created"}),

--- a/test/integration/action_client/callbacks_test.rb
+++ b/test/integration/action_client/callbacks_test.rb
@@ -55,7 +55,7 @@ module ActionClient
         status: 422
       )
       client = declare_client {
-        after_submit :raise_error, with_status: 422
+        after_submit :raise_error, only_status: 422
 
         def create
           post url: "https://example.com/articles"
@@ -182,7 +182,7 @@ module ActionClient
       stub_request(:post, "https://example.com/articles").and_return(status: 200)
       error_class = Class.new(ArgumentError)
       client = declare_client {
-        after_submit(with_status: 422) { raise error_class }
+        after_submit(only_status: 422) { raise error_class }
 
         def create
           post url: "https://example.com/articles"
@@ -202,7 +202,7 @@ module ActionClient
       )
       error_class = Class.new(ArgumentError)
       client = declare_client {
-        after_submit(with_status: 422) { |body| raise error_class, body.fetch("error") }
+        after_submit(only_status: 422) { |body| raise error_class, body.fetch("error") }
 
         def create
           post url: "https://example.com/articles"
@@ -222,7 +222,7 @@ module ActionClient
       )
       error_class = Class.new(ArgumentError)
       client = declare_client {
-        after_submit with_status: [:unauthorized, 403] do |body|
+        after_submit only_status: [:unauthorized, 403] do |body|
           raise error_class, body.fetch("error")
         end
 
@@ -244,7 +244,7 @@ module ActionClient
       )
       error_class = Class.new(ArgumentError)
       client = declare_client {
-        after_submit with_status: 422 do |body|
+        after_submit only_status: 422 do |body|
           raise error_class, body.fetch("error")
         end
 
@@ -266,7 +266,7 @@ module ActionClient
       )
       error_class = Class.new(ArgumentError)
       client = declare_client {
-        after_submit with_status: [401, 403] do |body|
+        after_submit only_status: [401, 403] do |body|
           raise error_class, body.fetch("error")
         end
 
@@ -288,7 +288,7 @@ module ActionClient
       )
       error_class = Class.new(ArgumentError)
       client = declare_client {
-        after_submit with_status: 400..500 do |body|
+        after_submit only_status: 400..500 do |body|
           raise error_class, body.fetch("error")
         end
 


### PR DESCRIPTION
 Rename `with_status:` to `only_status:`
---

In an effort to be more aligned with existing Rails controller action
filters, rename `with_status:` to `only_status:`, echoing the existing
`only:` option for `ActionController` callbacks.

 Add `except_status:` option to `after_submit`
---

Add support for `except_status:` to exclude `after_submit` execution for
a given set of HTTP Status codes.

To _exclude_ responses that don't match a particular set of HTTP Status
codes, declare the `after_submit` with `except_status:` instead:

```ruby
class ArticlesClient < ActionClient::Base
  after_submit except_status: [:success, :created] do |body|
    raise MyApplication::ArgumentError, body.fetch("error")
  end
end
```

 Add `only:` option to `after_submit`
---

Add support for `only:` to execute `after_submit` hooks for a given set
of action names.

In some cases, a `ActionClient::Base` descendant might want to execute
an `after_submit` hook for a certain set of Request actions.

To specify which actions an `after_submit` hook should execute for,
declare an `after_submit` that passes theirs names as the `only:`
option:

```ruby
class ArticlesClient < ActionClient::Base
  after_submit(only: [:create, :update]) { |body| Article.new(body) }

  def create
    # ...
  end

  def update
    # ...
  end

  def all
    # ...
  end
end
```

Add `except:` option to `after_submit`
---

Add support for `except:` to skip execution of `after_submit` hooks for
a given set of action names.

In some cases, a `ActionClient::Base` descendant might not want to
execute an `after_submit` hook for a certain set of Request actions.

To specify which actions an `after_submit` hook **should not** execute
for, declare an `after_submit` that passes theirs names as the `except:`
option:

```ruby
class ArticlesClient < ActionClient::Base
  after_submit(except: [:all]) { |body| Article.new(body) }

  def create
    # ...
  end

  def update
    # ...
  end

  def all
    # ...
  end
end
```

Improve developer experience of `after_submit`
---
    
Raise when mutually exclusive options are passed to `after_submit`,
including:
    
* both `only:` and `except:`
* both `only_status:` and `except_status:`
* both a `method_name` and a `block`
    
Additionally, add test coverage to ensure that options can be mixed and
matched.


