### PR TITLE
Add except_status: option to after_perform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for `except_status:` to omit execution of an `after_perform` hook
+  for an `ActionClient::SubmissionJob` descendant (added by [@seanpdoyle][])
+
 - Add support for `except:` to omit execution of `after_submit` hooks for a
   given set of action names (added by [@seanpdoyle][])
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ class ArticlesClientJob < ActionClient::SubmissionJob
 end
 ```
 
+Similarly, to execute an `after_perform` for statuses that **do not match**
+the given status codes, declare the `except_status:` option:
+
+```ruby
+# app/jobs/articles_client_job.rb
+class ArticlesClientJob < ActionClient::SubmissionJob
+  after_perform except_status: 200 do
+    status, headers, body = *response
+
+    Rails.logger.info("Retrying ArticlesClient job with status: #{status}...")
+
+    retry_job queue: "low_priority"
+  end
+end
+```
+
 Within the block, the Rack triplet is available as `response`.
 
 Next, configure your client class to enqueue jobs with that class:

--- a/test/integration/action_client/active_job_test.rb
+++ b/test/integration/action_client/active_job_test.rb
@@ -16,7 +16,7 @@ module ActionClient
 
       setup { MetricsClientJob.reset_callbacks(:perform) }
 
-      test "#after_perform without options always executes" do
+      test ".after_perform without options always executes" do
         stub_request(:get, "https://example.com/ping").to_return(
           headers: {"Content-Type": "application/json"},
           body: {status: "success"}.to_json
@@ -39,7 +39,7 @@ module ActionClient
 
       setup { MetricsClientJob.reset_callbacks(:perform) }
 
-      test "#after_perform executes a block for matching status codes" do
+      test ".after_perform executes a block when the status codes match only_status:" do
         status, headers, body = []
         stub_request(:get, "https://example.com/ping")
           .to_return(
@@ -64,14 +64,60 @@ module ActionClient
         assert_equal "error", body["status"]
       end
 
-      test "#after_perform does not execute a block for other status codes" do
+      test ".after_perform executes a block when the status codes does not match except_status:" do
+        status, headers, body = []
+        stub_request(:get, "https://example.com/ping")
+          .to_return(
+            headers: {"Content-Type": "application/json"},
+            body: {status: "error"}.to_json,
+            status: 500
+          ).times(1)
+          .then.to_return(status: 200)
+        MetricsClientJob.after_perform(except_status: 200) do
+          status, headers, body = *response
+          retry_job
+        end
+
+        with_submission_job MetricsClient, MetricsClientJob do
+          perform_enqueued_jobs { MetricsClient.ping.submit_later }
+        end
+
+        assert_performed_jobs(2, only: MetricsClientJob)
+        assert_requested :get, "https://example.com/ping", times: 2
+        assert_equal 500, status
+        assert_equal "application/json", headers["Content-Type"]
+        assert_equal "error", body["status"]
+      end
+
+      test ".after_perform skips execution of blocks when the status code does not match only_status:" do
         stub_request(:get, "https://example.com/ping").to_return(status: 200)
+        MetricsClientJob.after_perform(only_status: 400..599) { raise }
 
         with_submission_job MetricsClient, MetricsClientJob do
           perform_enqueued_jobs { MetricsClient.ping.submit_later }
         end
 
         assert_no_enqueued_jobs
+      end
+
+      test ".after_perform skips execution of blocks when the status code does matches except_status:" do
+        stub_request(:get, "https://example.com/ping").to_return(status: 200)
+        MetricsClientJob.after_perform(except_status: 200) { raise }
+
+        with_submission_job MetricsClient, MetricsClientJob do
+          perform_enqueued_jobs { MetricsClient.ping.submit_later }
+        end
+
+        assert_no_enqueued_jobs
+      end
+
+      test ".after_perform raises when both only_status: and except_status: are present" do
+        exception = assert_raises {
+          MetricsClientJob.after_perform(except_status: 200, only_status: 200) { raise }
+        }
+
+        assert_includes exception.message, "except_status:"
+        assert_includes exception.message, "only_status:"
       end
     end
   end


### PR DESCRIPTION
Add support for `except_status:` to omit execution of an `after_perform`
hook ActionClient::SubmissionJob` descendant.

To execute an `after_perform` for statuses that **do not match** the
given status codes, declare the `except_status:` option:

```ruby
class ArticlesClientJob < ActionClient::SubmissionJob
  after_perform except_status: 200 do
    status, headers, body = *response

    Rails.logger.info("Retrying ArticlesClient job with status: #{status}...")

    retry_job queue: "low_priority"
  end
end
```