### PR TITLE
Reformat with standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,4 @@ jobs:
       run: |
         bin/setup
         bin/rails test
+        bundle exec standardrb --no-fix

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,10 @@ end
 
 gem "rails", rails_constraint
 
+group :development, :test do
+  gem "standard"
+end
+
 group :test do
   gem "minitest-around", require: "minitest/around/unit"
   gem "webmock", require: "webmock/minitest"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Declare your gem's dependencies in action_client.gemspec.
@@ -16,10 +16,10 @@ gemspec
 
 rails_version = ENV.fetch("RAILS_VERSION", "6.0")
 
-if rails_version == "master"
-  rails_constraint = {github: "rails/rails"}
+rails_constraint = if rails_version == "master"
+  {github: "rails/rails"}
 else
-  rails_constraint = "#{rails_version}.0"
+  "#{rails_version}.0"
 end
 
 gem "rails", rails_constraint

--- a/README.md
+++ b/README.md
@@ -448,7 +448,15 @@ $ bundle
 ```
 
 ## Contributing
-Contribution directions go here.
+
+This project's Ruby code is linted by [standard][]. New code that is added
+through Pull Requests cannot include any linting violations.
+
+To helper ensure that your contributions don't contain any violations, please
+consider [integrating Standard into your editor workflow][].
+
+[standard]: https://github.com/testdouble/standard
+[standard-editor]: https://github.com/testdouble/standard#how-do-i-run-standard-in-my-editor
 
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/Rakefile
+++ b/Rakefile
@@ -1,28 +1,28 @@
 begin
-  require 'bundler/setup'
+  require "bundler/setup"
 rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+  puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
 
-require 'rdoc/task'
+require "rdoc/task"
 
 RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'ActionClient'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.md')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+  rdoc.rdoc_dir = "rdoc"
+  rdoc.title = "ActionClient"
+  rdoc.options << "--line-numbers"
+  rdoc.rdoc_files.include("README.md")
+  rdoc.rdoc_files.include("lib/**/*.rb")
 end
 
-load 'rails/tasks/statistics.rake'
+load "rails/tasks/statistics.rake"
 
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"
 
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
   t.verbose = false
 end
 

--- a/action_client.gemspec
+++ b/action_client.gemspec
@@ -5,14 +5,14 @@ require "action_client/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
-  spec.name        = "action_client"
-  spec.version     = ActionClient::VERSION
-  spec.authors     = ["Sean Doyle"]
-  spec.email       = ["sean.p.doyle24@gmail.com"]
-  spec.homepage    = "https://github.com/seanpdoyle/action_client"
-  spec.summary     = "HTTP Clients, the Rails way"
+  spec.name = "action_client"
+  spec.version = ActionClient::VERSION
+  spec.authors = ["Sean Doyle"]
+  spec.email = ["sean.p.doyle24@gmail.com"]
+  spec.homepage = "https://github.com/seanpdoyle/action_client"
+  spec.summary = "HTTP Clients, the Rails way"
   spec.description = "Write HTTP clients in the style of Controllers and Mailers"
-  spec.license     = "MIT"
+  spec.license = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.

--- a/app/controllers/action_client/clients_controller.rb
+++ b/app/controllers/action_client/clients_controller.rb
@@ -2,7 +2,7 @@ module ActionClient
   class ClientsController < ActionClient::ApplicationController
     def index
       render locals: {
-        clients: ActionClient::Preview.all,
+        clients: ActionClient::Preview.all
       }
     end
 
@@ -11,7 +11,7 @@ module ActionClient
 
       if preview.present?
         render locals: {
-          client: preview,
+          client: preview
         }
       else
         raise AbstractController::ActionNotFound

--- a/app/controllers/action_client/previews_controller.rb
+++ b/app/controllers/action_client/previews_controller.rb
@@ -9,7 +9,7 @@ module ActionClient
 
         render locals: {
           client: client,
-          preview: preview,
+          preview: preview
         }
       else
         raise AbstractController::ActionNotFound

--- a/lib/action_client/applications/net/http_client.rb
+++ b/lib/action_client/applications/net/http_client.rb
@@ -30,8 +30,8 @@ module ActionClient
 
           ActionDispatch::Response.new(
             response.code,
-            response.each_header.to_h.transform_keys { |key| key.titleize.gsub(" ", "-") },
-            Array(response.body),
+            response.each_header.to_h.transform_keys { |key| key.titleize.tr(" ", "-") },
+            Array(response.body)
           ).to_a
         end
       end

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -57,7 +57,7 @@ module ActionClient
 
       def method_missing(method_name, *arguments)
         if action_methods.include?(method_name.to_s)
-          self.new(middleware).process(method_name, *arguments)
+          new(middleware).process(method_name, *arguments)
         else
           super
         end
@@ -129,12 +129,12 @@ module ActionClient
         Rack::QUERY_STRING => query_parameters.to_query,
         Rack::RACK_INPUT => StringIO.new(payload),
         Rack::RACK_URL_SCHEME => uri.scheme,
-        Rack::REQUEST_METHOD => method.to_s.upcase,
+        Rack::REQUEST_METHOD => method.to_s.upcase
       )
 
       headers.with_defaults(
         "Accept" => content_type,
-        Rack::CONTENT_TYPE => content_type,
+        Rack::CONTENT_TYPE => content_type
       ).each do |key, value|
         request.headers[key] = value
       end
@@ -147,11 +147,11 @@ module ActionClient
         @middleware,
         request.env,
         client: self,
-        action_arguments: @action_arguments,
+        action_arguments: @action_arguments
       )
     end
 
-    %i(
+    %i[
       connect
       delete
       get
@@ -161,7 +161,7 @@ module ActionClient
       post
       put
       trace
-    ).each do |verb|
+    ].each do |verb|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{verb}(**options, &block)
           build_request(method: #{verb.inspect}, **options, &block)

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -64,7 +64,7 @@ module ActionClient
       end
 
       def respond_to_missing?(method_name, *arguments)
-        action_methods.include?(method_name) || super
+        action_methods.include?(method_name.to_s) || super
       end
     end
 

--- a/lib/action_client/callbacks/after_submit.rb
+++ b/lib/action_client/callbacks/after_submit.rb
@@ -15,7 +15,7 @@ module ActionClient
 
           callback.call(block)
         else
-          [ status_code, headers, body ]
+          [status_code, headers, body]
         end
       end
 

--- a/lib/action_client/callbacks/single_argument_callback.rb
+++ b/lib/action_client/callbacks/single_argument_callback.rb
@@ -1,6 +1,6 @@
 module ActionClient
   module Callbacks
-    SingleArgumentCallback = Struct.new(:status, :headers, :body) do
+    SingleArgumentCallback = Struct.new(:status, :headers, :body) {
       def call(block)
         modified_body = block.call(body).tap do |response|
           if response.nil?
@@ -13,6 +13,6 @@ module ActionClient
 
         [status, headers, modified_body]
       end
-    end
+    }
   end
 end

--- a/lib/action_client/callbacks/triple_argument_callback.rb
+++ b/lib/action_client/callbacks/triple_argument_callback.rb
@@ -1,6 +1,6 @@
 module ActionClient
   module Callbacks
-    TripleArgumentCallback = Struct.new(:status, :headers, :body) do
+    TripleArgumentCallback = Struct.new(:status, :headers, :body) {
       def call(block)
         block.call(status, headers, body).tap do |response|
           response = Array(response)
@@ -16,6 +16,6 @@ module ActionClient
           end
         end
       end
-    end
+    }
   end
 end

--- a/lib/action_client/engine.rb
+++ b/lib/action_client/engine.rb
@@ -16,7 +16,7 @@ module ActionClient
     initializer "action_client.routes" do |app|
       unless Rails.env.production?
         app.routes.prepend do
-          mount ActionClient::Engine => "/rails/action_client", as: :action_client_engine
+          mount ActionClient::Engine => "/rails/action_client", :as => :action_client_engine
         end
       end
     end

--- a/lib/action_client/middleware/response_parser.rb
+++ b/lib/action_client/middleware/response_parser.rb
@@ -20,7 +20,7 @@ module ActionClient
           end
         end
 
-        [ status, headers, body ]
+        [status, headers, body]
       end
     end
   end

--- a/lib/action_client/submittable_request.rb
+++ b/lib/action_client/submittable_request.rb
@@ -14,13 +14,13 @@ module ActionClient
 
       ActionClient::Response.new(body, status, headers)
     end
-    alias_method :submit_now, :submit
+    alias submit_now submit
 
     def submit_later(**options)
       @client.submission_job.set(options).perform_later(
         @client.class.name,
         @client.action_name.to_s,
-        *@action_arguments,
+        *@action_arguments
       )
     end
   end

--- a/lib/action_client/utils.rb
+++ b/lib/action_client/utils.rb
@@ -1,18 +1,16 @@
 module ActionClient
   class Utils
     def self.headers_to_hash(rack_headers)
-      rack_headers.reduce({}) do |rewritten_headers, (key, value)|
+      rack_headers.each_with_object({}) do |(key, value), rewritten_headers|
         if key.starts_with?("HTTP_") || ActionDispatch::Http::Headers::CGI_VARIABLES.include?(key)
           rewritten_headers.merge!(titlecase_keys(key => value))
         end
-
-        rewritten_headers
       end
     end
 
     def self.titlecase_keys(headers)
       headers.reduce({}) do |rewritten_headers, (key, value)|
-        formatted_key = key.sub(%r{\AHTTP_}, "").titleize.gsub(" ", "-")
+        formatted_key = key.delete_prefix("HTTP_").titleize.tr(" ", "-")
 
         rewritten_headers.merge(formatted_key => value)
       end

--- a/lib/action_client/version.rb
+++ b/lib/action_client/version.rb
@@ -1,3 +1,3 @@
 module ActionClient
-  VERSION = '0.1.0'
+  VERSION = "0.1.0"
 end

--- a/test/action_client/applications/net/http_client_test.rb
+++ b/test/action_client/applications/net/http_client_test.rb
@@ -8,7 +8,7 @@ module ActionClient
           uri = URI("https://www.example.com/articles")
           stub_request(:any, Regexp.new(uri.hostname)).and_return(
             body: %({"responded": true}),
-            status: 201,
+            status: 201
           )
           payload = %({"requested": true})
           adapter = ActionClient::Applications::Net::HttpClient.new
@@ -18,7 +18,7 @@ module ActionClient
             Rack::REQUEST_METHOD => "POST",
             Rack::PATH_INFO => uri.path,
             Rack::RACK_INPUT => StringIO.new(payload),
-            "CONTENT_TYPE" => "application/json",
+            "CONTENT_TYPE" => "application/json"
           )
 
           code, _, body = adapter.call(request.env)
@@ -28,8 +28,8 @@ module ActionClient
           assert_requested :post, uri, {
             body: %({"requested": true}),
             headers: {
-              "Content-Type" => "application/json",
-            },
+              "Content-Type" => "application/json"
+            }
           }
         end
 
@@ -37,7 +37,7 @@ module ActionClient
           uri = URI("https://www.example.com/articles")
           stub_request(:any, Regexp.new(uri.hostname)).and_return(
             body: %({"responded": true}),
-            status: 200,
+            status: 200
           )
           adapter = ActionClient::Applications::Net::HttpClient.new
           request = ActionDispatch::Request.new(
@@ -45,7 +45,7 @@ module ActionClient
             Rack::PATH_INFO => uri.path,
             Rack::RACK_URL_SCHEME => uri.scheme,
             Rack::REQUEST_METHOD => "GET",
-            "CONTENT_TYPE" => "application/json",
+            "CONTENT_TYPE" => "application/json"
           )
 
           code, _, body = adapter.call(request.env)
@@ -54,8 +54,8 @@ module ActionClient
           assert_equal 200, code
           assert_requested :get, uri, {
             headers: {
-              "Content-Type" => "application/json",
-            },
+              "Content-Type" => "application/json"
+            }
           }
         end
       end

--- a/test/action_client/middleware/response_parser_test.rb
+++ b/test/action_client/middleware/response_parser_test.rb
@@ -14,7 +14,7 @@ module ActionClient
         end
         middleware = ActionClient::Middleware::ResponseParser.new(app)
 
-        status, headers, body = middleware.call({
+        *, body = middleware.call({
           Rack::RACK_INPUT => payload.lines
         })
 
@@ -32,7 +32,7 @@ module ActionClient
         end
         middleware = ActionClient::Middleware::ResponseParser.new(app)
 
-        status, headers, document = middleware.call({
+        *, document = middleware.call({
           Rack::RACK_INPUT => payload.lines
         })
 
@@ -51,7 +51,7 @@ module ActionClient
         end
         middleware = ActionClient::Middleware::ResponseParser.new(app)
 
-        status, headers, body = middleware.call({
+        *, body = middleware.call({
           Rack::RACK_INPUT => payload.lines
         })
 

--- a/test/action_client/middleware/response_parser_test.rb
+++ b/test/action_client/middleware/response_parser_test.rb
@@ -8,14 +8,14 @@ module ActionClient
         app = proc do |env|
           [
             200,
-            { Rack::CONTENT_TYPE => "application/json" },
-            env[Rack::RACK_INPUT],
+            {Rack::CONTENT_TYPE => "application/json"},
+            env[Rack::RACK_INPUT]
           ]
         end
         middleware = ActionClient::Middleware::ResponseParser.new(app)
 
         status, headers, body = middleware.call({
-          Rack::RACK_INPUT => payload.lines,
+          Rack::RACK_INPUT => payload.lines
         })
 
         assert_equal({"response" => true}, body)
@@ -26,14 +26,14 @@ module ActionClient
         app = proc do |env|
           [
             200,
-            { Rack::CONTENT_TYPE => "application/xml" },
-            env[Rack::RACK_INPUT],
+            {Rack::CONTENT_TYPE => "application/xml"},
+            env[Rack::RACK_INPUT]
           ]
         end
         middleware = ActionClient::Middleware::ResponseParser.new(app)
 
         status, headers, document = middleware.call({
-          Rack::RACK_INPUT => payload.lines,
+          Rack::RACK_INPUT => payload.lines
         })
 
         assert_equal "node", document.root.name
@@ -46,13 +46,13 @@ module ActionClient
           [
             200,
             {},
-            env[Rack::RACK_INPUT],
+            env[Rack::RACK_INPUT]
           ]
         end
         middleware = ActionClient::Middleware::ResponseParser.new(app)
 
         status, headers, body = middleware.call({
-          Rack::RACK_INPUT => payload.lines,
+          Rack::RACK_INPUT => payload.lines
         })
 
         assert_equal payload, body

--- a/test/action_client/response_test.rb
+++ b/test/action_client/response_test.rb
@@ -5,42 +5,50 @@ module ActionClient
     test ".[] inherits behavior of Rack::Response" do
       response = ActionClient::Response[
         "200",
-        {"Accept" => "text/plain"},
+        {"Content-Type" => "text/plain"},
         "body string",
       ]
 
       status, headers, body = *response
 
       assert_equal 200, status
-      assert_equal "text/plain", headers["Accept"]
+      assert_equal "text/plain", headers["Content-Type"]
+      assert_equal "body string", body
+    end
+
+    test "#to_a returns a Rack triplet" do
+      response = ActionClient::Response.new(
+        "body string",
+        "200",
+        {"Content-Type" => "text/plain"}
+      )
+
+      status, headers, body = *response
+
+      assert_equal 200, status
+      assert_equal "text/plain", headers["Content-Type"]
       assert_equal "body string", body
     end
 
     test "#initialize sets a body String, without buffering it" do
       response = ActionClient::Response.new("body string")
 
-      status, headers, body = *response
-
-      assert_equal 200, status
-      assert_equal "body string", body
+      assert_equal 200, response.status
+      assert_equal "body string", response.body
     end
 
     test "#initialize sets a body Hash, without buffering it" do
       response = ActionClient::Response.new({response: "body"})
 
-      status, headers, body = *response
-
-      assert_equal 200, status
-      assert_equal "body", body.fetch(:response)
+      assert_equal 200, response.status
+      assert_equal "body", response.body.fetch(:response)
     end
 
     test "#initialize sets a body Array, without buffering it" do
       response = ActionClient::Response.new([{response: "body"}])
 
-      status, headers, body = *response
-
-      assert_equal 200, status
-      assert_equal [{response: "body"}], body
+      assert_equal 200, response.status
+      assert_equal [{response: "body"}], response.body
     end
   end
 end

--- a/test/action_client_test.rb
+++ b/test/action_client_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ActionClient::Test < ActiveSupport::TestCase
   test "truth" do

--- a/test/controllers/action_client/clients_controller_test.rb
+++ b/test/controllers/action_client/clients_controller_test.rb
@@ -23,7 +23,7 @@ module ActionClient
 
       assert_select(
         %(a[href*="#{client_path(ArticlesClientPreview.preview_name)}"]),
-        text: ArticlesClientPreview.preview_name,
+        text: ArticlesClientPreview.preview_name
       )
     end
 
@@ -32,7 +32,7 @@ module ActionClient
 
       assert_select(
         %(a[href*="#{clients_path}"]),
-        text: ActionClient::Preview.name.pluralize,
+        text: ActionClient::Preview.name.pluralize
       )
     end
 
@@ -42,7 +42,7 @@ module ActionClient
       assert_select "li", count: 1 do
         assert_select(
           %(a[href*="#{client_preview_path(ArticlesClientPreview.preview_name, "create")}"]),
-          text: "create",
+          text: "create"
         )
       end
     end

--- a/test/controllers/action_client/previews_controller_test.rb
+++ b/test/controllers/action_client/previews_controller_test.rb
@@ -8,7 +8,7 @@ module ActionClient
 
     class ArticleClient < ActionClient::Base
       def create(title:)
-        post url: "https://example.com/articles", locals: { title: title }
+        post url: "https://example.com/articles", locals: {title: title}
       end
     end
 
@@ -24,13 +24,13 @@ module ActionClient
 
     test "action_client/previews displays information about the request" do
       declare_template "action_client/previews_controller_test/article_client/create.json.erb", <<~ERB
-      {"title": "<%= title %>"}
+        {"title": "<%= title %>"}
       ERB
 
       get client_preview_path(ArticlesClientPreview.preview_name, "create")
 
       assert_select "#url", text: "\nPOST https://example.com/articles\n"
-      assert_select "#body", text: JSON.pretty_generate({ title: "Hello, World" })
+      assert_select "#body", text: JSON.pretty_generate({title: "Hello, World"})
     end
 
     test "action_client/previews omits body when a template is not declared" do

--- a/test/dummy/Rakefile
+++ b/test/dummy/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/test/dummy/bin/rails
+++ b/test/dummy/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/test/dummy/bin/rake
+++ b/test/dummy/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/test/dummy/bin/setup
+++ b/test/dummy/bin/setup
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,13 +13,13 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/test/dummy/config.ru
+++ b/test/dummy/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,4 +1,4 @@
-require_relative 'boot'
+require_relative "boot"
 
 require "rails"
 # Pick the frameworks you want:
@@ -19,7 +19,7 @@ require "action_client"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults (
+    config.load_defaults(
       if ENV["RAILS_VERSION"] == "master"
         6.1
       else

--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+$LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -14,13 +14,13 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
@@ -30,7 +30,6 @@ Rails.application.configure do
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
-
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
@@ -37,7 +37,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -61,9 +61,9 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
   # Inserts middleware to perform automatic connection switching.

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -17,11 +17,11 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{ActiveSupport::Duration.hours(1)}"
+    "Cache-Control" => "public, max-age=#{ActiveSupport::Duration.hours(1).to_i}"
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 

--- a/test/dummy/config/puma.rb
+++ b/test/dummy/config/puma.rb
@@ -10,7 +10,7 @@ threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/test/integration/action_client/active_job_test.rb
+++ b/test/integration/action_client/active_job_test.rb
@@ -5,11 +5,11 @@ module ActionClient
   class ActiveJobTest < ActionClient::ActiveJobTestCase
     # freeze so that test cases don't accidentally leak state across classes
     MetricsClientJob = Class.new(ActionClient::SubmissionJob).freeze
-    MetricsClient = Class.new(ActionClient::Base) do
+    MetricsClient = Class.new(ActionClient::Base) {
       def ping
         get url: "https://example.com/ping"
       end
-    end
+    }
 
     class AfterPerformWithoutOptionsTest < ActiveJobTest
       MetricsClientJob = Class.new(ActionClient::SubmissionJob)
@@ -18,8 +18,8 @@ module ActionClient
 
       test "#after_perform without options always executes" do
         stub_request(:get, "https://example.com/ping").to_return(
-          headers: { "Content-Type": "application/json" },
-          body: { status: "success" }.to_json,
+          headers: {"Content-Type": "application/json"},
+          body: {status: "success"}.to_json
         )
         status, headers, body = []
         MetricsClientJob.after_perform { status, headers, body = *response }
@@ -41,13 +41,13 @@ module ActionClient
 
       test "#after_perform executes a block for matching status codes" do
         status, headers, body = []
-        stub_request(:get, "https://example.com/ping").
-          to_return(
-            headers: { "Content-Type": "application/json" },
-            body: { status: "error" }.to_json,
+        stub_request(:get, "https://example.com/ping")
+          .to_return(
+            headers: {"Content-Type": "application/json"},
+            body: {status: "error"}.to_json,
             status: 500
-          ).times(1).
-          then.to_return(status: 200)
+          ).times(1)
+          .then.to_return(status: 200)
         MetricsClientJob.after_perform(with_status: 400..599) do
           status, headers, body = *response
           retry_job

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -49,7 +49,7 @@ module ActionClient
     end
 
     test "constructs a POST request with a JSON body declared with instance variables" do
-      client = declare_client "article_client" do
+      client = declare_client("article_client") {
         default url: "https://example.com"
 
         def create(article:)
@@ -57,7 +57,7 @@ module ActionClient
 
           post path: "/articles"
         end
-      end
+      }
       declare_template "article_client/create.json.erb", <<~ERB
         <%= { title: @article.title }.to_json %>
       ERB
@@ -157,13 +157,13 @@ module ActionClient
     end
 
     test "constructs a DELETE request with a JSON body template" do
-      client = declare_client "article_client" do
+      client = declare_client("article_client") {
         default url: "https://example.com"
 
         def destroy(article:)
           delete path: "/articles/#{article.id}"
         end
-      end
+      }
       article = Article.new("1", nil)
       declare_template "article_client/destroy.json.erb", <<~JS
         {"confirm": true}
@@ -178,7 +178,7 @@ module ActionClient
     end
 
     test "constructs a PUT request with a JSON body declared with locals" do
-      client = declare_client "article_client" do
+      client = declare_client("article_client") {
         default url: "https://example.com"
 
         def update(article:)
@@ -186,7 +186,7 @@ module ActionClient
             article: article
           }
         end
-      end
+      }
       declare_template "article_client/update.json.erb", <<~ERB
         <%= { title: article.title }.to_json %>
       ERB
@@ -201,7 +201,7 @@ module ActionClient
     end
 
     test "constructs a PATCH request with an XML body declared with locals" do
-      client = declare_client "article_client" do
+      client = declare_client("article_client") {
         default url: "https://example.com"
 
         def update(article:)
@@ -209,7 +209,7 @@ module ActionClient
             article: article
           }
         end
-      end
+      }
       declare_template "article_client/update.xml.erb", <<~ERB
         <xml><%= article.title %></xml>
       ERB
@@ -224,14 +224,14 @@ module ActionClient
     end
 
     test "constructs a request with a body wrapped by a layout" do
-      client = declare_client "article_client" do
+      client = declare_client("article_client") {
         def create(article:)
           post \
             layout: "article_client",
             locals: {article: article},
             url: "https://example.com/special/articles"
         end
-      end
+      }
       declare_template "layouts/article_client.json.erb", <<~ERB
         { "response": <%= yield %> }
       ERB
@@ -428,13 +428,13 @@ module ActionClient
     end
 
     test "#submit makes an appropriate HTTP request" do
-      client = declare_client "article_client" do
+      client = declare_client("article_client") {
         default url: "https://example.com"
 
         def create(article:)
           post path: "/articles", locals: {article: article}
         end
-      end
+      }
       declare_template "article_client/create.json.erb", <<~ERB
         <%= { title: article.title }.to_json %>
       ERB
@@ -456,13 +456,13 @@ module ActionClient
     end
 
     test "#submit parses a JSON response based on the `Content-Type`" do
-      client = declare_client "article_client" do
+      client = declare_client("article_client") {
         default url: "https://example.com"
 
         def create(article:)
           post path: "/articles", locals: {article: article}
         end
-      end
+      }
       declare_template "article_client/create.json.erb", <<~ERB
         {"title": "<%= article.title %>"}
       ERB
@@ -481,13 +481,13 @@ module ActionClient
     end
 
     test "#submit parses an XML response based on the `Content-Type`" do
-      client = declare_client "article_client" do
+      client = declare_client("article_client") {
         default url: "https://example.com"
 
         def create(article:)
           post path: "/articles", locals: {article: article}
         end
-      end
+      }
       declare_template "article_client/create.xml.erb", <<~ERB
         <article title="<%= article.title %>"></article>
       ERB

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -8,10 +8,10 @@ module ActionClient
 
   class ActionMethodsTest < ClientTestCase
     test "the Base class responds to action methods" do
-      client = declare_client do
+      client = declare_client {
         def create
         end
-      end
+      }
 
       responds_to_create = client.respond_to?(:create)
       responds_to_destroy = client.respond_to?(:destroy)
@@ -21,13 +21,13 @@ module ActionClient
     end
 
     test "only exposes declared requests as action_methods" do
-      client = declare_client do
+      client = declare_client {
         def create
         end
 
         def destroy
         end
-      end
+      }
 
       action_methods = client.action_methods.to_a
 
@@ -37,11 +37,11 @@ module ActionClient
 
   class RequestsTest < ClientTestCase
     test "constructs a request that encodes the port" do
-      client = declare_client do
+      client = declare_client {
         def create
           post url: "https://localhost:3000/articles"
         end
-      end
+      }
 
       request = client.create
 
@@ -67,19 +67,19 @@ module ActionClient
 
       assert_equal "POST", request.method
       assert_equal "https://example.com/articles", request.original_url
-      assert_equal({ "title" => "Article Title" }, JSON.parse(request.body.read))
+      assert_equal({"title" => "Article Title"}, JSON.parse(request.body.read))
       assert_equal "application/json", request.headers["Content-Type"]
     end
 
     test "constructs a GET request without declaring a body template" do
-      client = declare_client do
-        default headers: { "Content-Type": "application/json" }
+      client = declare_client {
+        default headers: {"Content-Type": "application/json"}
         default url: "https://example.com"
 
         def all
           get path: "/articles"
         end
-      end
+      }
 
       request = client.all
 
@@ -90,13 +90,13 @@ module ActionClient
     end
 
     test "constructs an OPTIONS request without declaring a body template" do
-      client = declare_client do
+      client = declare_client {
         default url: "https://example.com"
 
         def status
           options path: "/status"
         end
-      end
+      }
 
       request = client.status
 
@@ -106,13 +106,13 @@ module ActionClient
     end
 
     test "constructs a HEAD request without declaring a body template" do
-      client = declare_client do
+      client = declare_client {
         default url: "https://example.com"
 
         def status
           head path: "/status"
         end
-      end
+      }
 
       request = client.status
 
@@ -122,13 +122,13 @@ module ActionClient
     end
 
     test "constructs a TRACE request without declaring a body template" do
-      client = declare_client do
+      client = declare_client {
         default url: "https://example.com"
 
         def status
           trace path: "/status"
         end
-      end
+      }
 
       request = client.status
 
@@ -138,14 +138,14 @@ module ActionClient
     end
 
     test "constructs a DELETE request without declaring a body template" do
-      client = declare_client do
-        default headers: { "Content-Type": "application/json" }
+      client = declare_client {
+        default headers: {"Content-Type": "application/json"}
         default url: "https://example.com"
 
         def destroy(article:)
           delete path: "/articles/#{article.id}"
         end
-      end
+      }
       article = Article.new("1", nil)
 
       request = client.destroy(article: article)
@@ -166,14 +166,14 @@ module ActionClient
       end
       article = Article.new("1", nil)
       declare_template "article_client/destroy.json.erb", <<~JS
-      {"confirm": true}
+        {"confirm": true}
       JS
 
       request = client.destroy(article: article)
 
       assert_equal "DELETE", request.method
       assert_equal "https://example.com/articles/1", request.original_url
-      assert_equal({ "confirm"=> true }, JSON.parse(request.body.read))
+      assert_equal({"confirm" => true}, JSON.parse(request.body.read))
       assert_equal "application/json", request.headers["Content-Type"]
     end
 
@@ -183,7 +183,7 @@ module ActionClient
 
         def update(article:)
           put path: "/articles/#{article.id}", locals: {
-            article: article,
+            article: article
           }
         end
       end
@@ -196,7 +196,7 @@ module ActionClient
 
       assert_equal "PUT", request.method
       assert_equal "https://example.com/articles/1", request.original_url
-      assert_equal({ "title" => "Article Title" }, JSON.parse(request.body.read))
+      assert_equal({"title" => "Article Title"}, JSON.parse(request.body.read))
       assert_equal "application/json", request.headers["Content-Type"]
     end
 
@@ -206,7 +206,7 @@ module ActionClient
 
         def update(article:)
           patch path: "/articles/#{article.id}", locals: {
-            article: article,
+            article: article
           }
         end
       end
@@ -228,32 +228,32 @@ module ActionClient
         def create(article:)
           post \
             layout: "article_client",
-            locals: { article: article },
+            locals: {article: article},
             url: "https://example.com/special/articles"
         end
       end
       declare_template "layouts/article_client.json.erb", <<~ERB
-      { "response": <%= yield %> }
+        { "response": <%= yield %> }
       ERB
       declare_template "article_client/create.json.erb", <<~ERB
-      { "title": "<%= article.title %>" }
+        { "title": "<%= article.title %>" }
       ERB
       article = Article.new(nil, "From Layout")
 
       request = client.create(article: article)
 
       assert_equal(
-        { "response" => { "title" => "From Layout" } },
+        {"response" => {"title" => "From Layout"}},
         JSON.parse(request.body.read)
       )
     end
 
     test "constructs a request with the full URL passed as an option" do
-      client = declare_client do
+      client = declare_client {
         def create(article:)
           post url: "https://example.com/special/articles"
         end
-      end
+      }
 
       request = client.create(article: nil)
 
@@ -261,14 +261,14 @@ module ActionClient
     end
 
     test "constructs a request with additional headers" do
-      client = declare_client do
+      client = declare_client {
         default url: "https://example.com"
-        default headers: { "Content-Type": "application/json" }
+        default headers: {"Content-Type": "application/json"}
 
         def create(article:)
-          post path: "/articles", headers: { "X-My-Header": "hello!" }
+          post path: "/articles", headers: {"X-My-Header": "hello!"}
         end
-      end
+      }
 
       request = client.create(article: nil)
 
@@ -277,14 +277,14 @@ module ActionClient
     end
 
     test "constructs a request with overridden headers" do
-      client = declare_client do
+      client = declare_client {
         default url: "https://example.com"
-        default headers: { "Content-Type": "application/json" }
+        default headers: {"Content-Type": "application/json"}
 
         def create(article:)
-          post path: "/articles", headers: { "Content-Type": "application/xml" }
+          post path: "/articles", headers: {"Content-Type": "application/xml"}
         end
-      end
+      }
 
       request = client.create(article: nil)
 
@@ -292,13 +292,13 @@ module ActionClient
     end
 
     test "joins the path: to the default url:" do
-      client = declare_client do
+      client = declare_client {
         default url: "https://example.com"
 
         def all
           get path: "articles"
         end
-      end
+      }
 
       request = client.all
 
@@ -306,11 +306,11 @@ module ActionClient
     end
 
     test "supports query parameters in the url: option" do
-      client = declare_client do
+      client = declare_client {
         def all
           get url: "https://example.com/articles?q=all"
         end
-      end
+      }
 
       request = client.all
 
@@ -318,13 +318,13 @@ module ActionClient
     end
 
     test "supports query parameters in the path: option" do
-      client = declare_client do
+      client = declare_client {
         default url: "https://example.com"
 
         def all
           get path: "articles?q=all"
         end
-      end
+      }
 
       request = client.all
 
@@ -332,11 +332,11 @@ module ActionClient
     end
 
     test "supports query in the query: option" do
-      client = declare_client do
+      client = declare_client {
         def all
-          get url: "https://example.com/articles", query: { q: :all }
+          get url: "https://example.com/articles", query: {q: :all}
         end
-      end
+      }
 
       request = client.all
 
@@ -344,24 +344,23 @@ module ActionClient
     end
 
     test "merges URL query parameters with those passed under the query: option" do
-      client = declare_client do
+      client = declare_client {
         def all(search_term:, **query_parameters)
           get url: "https://example.com/articles?q=#{search_term}", query: query_parameters
         end
-      end
+      }
 
       request = client.all(search_term: "foo", page: 1)
 
       assert_equal "https://example.com/articles?page=1&q=foo", request.url
     end
 
-
     test "raises an ArgumentError if path: provided without default url:" do
-      client = declare_client do
+      client = declare_client {
         def create(article:)
           post path: "ignored"
         end
-      end
+      }
 
       assert_raises ArgumentError, /path|url/ do
         client.create(article: nil)
@@ -369,11 +368,11 @@ module ActionClient
     end
 
     test "raises an ArgumentError when both url: and path: are provided" do
-      client = declare_client do
+      client = declare_client {
         def create(article:)
           post url: "ignored", path: "ignored"
         end
-      end
+      }
 
       assert_raises ArgumentError, /path|url/ do
         client.create(article: nil)
@@ -381,24 +380,24 @@ module ActionClient
     end
 
     test "ensures each descendant gets its own copy of defaults" do
-      application_client = declare_client do
+      application_client = declare_client {
         default url: "https://example.com"
-      end
-      articles_client = Class.new(application_client) do
+      }
+      articles_client = Class.new(application_client) {
         default url: "https://example.com/articles"
 
         def create
           post
         end
-      end
+      }
 
-      tags_client = Class.new(application_client) do
+      tags_client = Class.new(application_client) {
         default url: "https://example.com/tags"
 
         def create
           post
         end
-      end
+      }
 
       articles_request = articles_client.create
       tags_request = tags_client.create
@@ -410,15 +409,15 @@ module ActionClient
 
   class ResponsesTest < ClientTestCase
     test "responses can be splatted into Rack triplets" do
-      client = declare_client do
+      client = declare_client {
         def all
           get url: "https://example.com/articles"
         end
-      end
+      }
       stub_request(:any, "https://example.com/articles").and_return(
         body: %({"responded": true}),
         headers: {"Content-Type": "application/json"},
-        status: 201,
+        status: 201
       )
 
       status, headers, body = *client.all.submit
@@ -433,17 +432,17 @@ module ActionClient
         default url: "https://example.com"
 
         def create(article:)
-          post path: "/articles", locals: { article: article }
+          post path: "/articles", locals: {article: article}
         end
       end
       declare_template "article_client/create.json.erb", <<~ERB
-      <%= { title: article.title }.to_json %>
+        <%= { title: article.title }.to_json %>
       ERB
       article = Article.new(nil, "Article Title")
       stub_request(:any, Regexp.new("example.com")).and_return(
         body: %({"responded": true}),
         headers: {"Content-Type": "application/json"},
-        status: 201,
+        status: 201
       )
 
       response = client.create(article: article).submit
@@ -452,7 +451,7 @@ module ActionClient
       assert_equal response.body, {"responded" => true}
       assert_requested :post, "https://example.com/articles", {
         body: {"title": "Article Title"},
-        headers: { "Content-Type" => "application/json" },
+        headers: {"Content-Type" => "application/json"}
       }
     end
 
@@ -461,17 +460,17 @@ module ActionClient
         default url: "https://example.com"
 
         def create(article:)
-          post path: "/articles", locals: { article: article }
+          post path: "/articles", locals: {article: article}
         end
       end
       declare_template "article_client/create.json.erb", <<~ERB
-      {"title": "<%= article.title %>"}
+        {"title": "<%= article.title %>"}
       ERB
       article = Article.new(nil, "Encoded as JSON")
       stub_request(:post, %r{example.com}).and_return(
         body: {"title": article.title, id: 1}.to_json,
         headers: {"Content-Type": "application/json;charset=UTF-8"},
-        status: 201,
+        status: 201
       )
 
       response = client.create(article: article).submit
@@ -486,17 +485,17 @@ module ActionClient
         default url: "https://example.com"
 
         def create(article:)
-          post path: "/articles", locals: { article: article }
+          post path: "/articles", locals: {article: article}
         end
       end
       declare_template "article_client/create.xml.erb", <<~ERB
-      <article title="<%= article.title %>"></article>
+        <article title="<%= article.title %>"></article>
       ERB
       article = Article.new(nil, "Encoded as XML")
       stub_request(:post, %r{example.com}).and_return(
         body: %(<article title="#{article.title}" id="1"></article>),
         headers: {"Content-Type": "application/xml"},
-        status: 201,
+        status: 201
       )
 
       response = client.create(article: article).submit

--- a/test/integration/action_client/callbacks_test.rb
+++ b/test/integration/action_client/callbacks_test.rb
@@ -82,8 +82,13 @@ module ActionClient
         status: 200
       )
       client = declare_client {
-        after_submit { |status, headers, body| body["status"] = "modified"; [status, headers, body] }
-        after_submit { |status, headers, body| [status, headers, body.transform_keys(&:upcase)] }
+        after_submit do |status, headers, body|
+          body["status"] = "modified"
+          [status, headers, body]
+        end
+        after_submit do |status, headers, body|
+          [status, headers, body.transform_keys(&:upcase)]
+        end
 
         def create
           post url: "https://example.com/articles" do |status, headers, body|
@@ -264,7 +269,10 @@ module ActionClient
 
     test "each time a request is submitted, it receives its own middleware stack" do
       client = declare_client {
-        after_submit { |body| body["callbacks"].push("class"); body }
+        after_submit do |body|
+          body["callbacks"].push("class")
+          body
+        end
 
         def create
           post url: "https://example.com/articles" do |body|

--- a/test/integration/action_client/configuration_test.rb
+++ b/test/integration/action_client/configuration_test.rb
@@ -8,13 +8,13 @@ module ActionClient
         test:
           url: "https://example.com"
       YAML
-      client = declare_client "articles_client" do
+      client = declare_client("articles_client") {
         default url: configuration.url
 
         def all
           get path: "articles"
         end
-      end
+      }
 
       request = client.all
 
@@ -22,13 +22,13 @@ module ActionClient
     end
 
     test "defaults to an empty configuration when a file is not present" do
-      client = declare_client "articles_client" do
+      client = declare_client("articles_client") {
         default url: configuration.url || "https://example.com"
 
         def all
           get path: "articles"
         end
-      end
+      }
 
       request = client.all
 

--- a/test/integration/action_client/configuration_test.rb
+++ b/test/integration/action_client/configuration_test.rb
@@ -5,8 +5,8 @@ module ActionClient
   class ConfigurationTestCase < ActionClient::IntegrationTestCase
     test "can read configuration values from a file" do
       declare_config "clients/articles.yml", <<~YAML
-      test:
-        url: "https://example.com"
+        test:
+          url: "https://example.com"
       YAML
       client = declare_client "articles_client" do
         default url: configuration.url

--- a/test/integration/action_client/submit_later_test.rb
+++ b/test/integration/action_client/submit_later_test.rb
@@ -3,11 +3,11 @@ require "active_job_test_case"
 
 module ActionClient
   class SubmitLaterTest < ActionClient::ActiveJobTestCase
-    MetricsClient = Class.new(ActionClient::Base) do
+    MetricsClient = Class.new(ActionClient::Base) {
       def ping(path = "ping", **options)
         get url: "https://example.com/#{path}", query: options
       end
-    end
+    }
 
     MetricsClientJob = Class.new(ActionClient::SubmissionJob)
 

--- a/test/integration_test_case.rb
+++ b/test/integration_test_case.rb
@@ -8,7 +8,7 @@ module ActionClient
     def declare_client(controller_path = nil, &block)
       Class.new(ActionClient::Base).tap do |client_class|
         if controller_path.present?
-          client_class.class_eval <<~RUBY
+          client_class.class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def self.controller_path
               #{controller_path.inspect}
             end

--- a/test/integration_test_case.rb
+++ b/test/integration_test_case.rb
@@ -9,9 +9,9 @@ module ActionClient
       Class.new(ActionClient::Base).tap do |client_class|
         if controller_path.present?
           client_class.class_eval <<~RUBY
-          def self.controller_path
-            #{controller_path.inspect}
-          end
+            def self.controller_path
+              #{controller_path.inspect}
+            end
           RUBY
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,5 +6,3 @@ require "rails/test_help"
 
 # Filter out the backtrace from minitest while preserving the one from other libraries.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
-
-


### PR DESCRIPTION
Use standardrb to automatically fix formatting
===

This commit was generated by executing:

```bash
standardrb --fix
```

There are additional linting violations, but those cannot be fixed
automatically.

Resolve linting violations that cannot auto-fix
===

The `standardrb --fix` command is sometimes incapable of auto-fixing all
violations. This commit includes suggested fixes there required
developer intervention. The changes were guided by the following
StandardRB-generated output:

```ruby
❯ standardrb
standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
  lib/action_client/base.rb:56:7: Style/MissingRespondToMissing: When using `method_missing`, define `respond_to_missing?`.
  test/action_client/middleware/response_parser_test.rb:17:9: Lint/UselessAssignment: Useless assignment to variable - `status`. Use `_` or `_status` as a variable name to indicate that it won't
be used.
  test/action_client/middleware/response_parser_test.rb:17:17: Lint/UselessAssignment: Useless assignment to variable - `headers`. Use `_` or `_headers` as a variable name to indicate that it won
't be used.
  test/action_client/middleware/response_parser_test.rb:35:9: Lint/UselessAssignment: Useless assignment to variable - `status`. Use `_` or `_status` as a variable name to indicate that it won't
be used.
  test/action_client/middleware/response_parser_test.rb:35:17: Lint/UselessAssignment: Useless assignment to variable - `headers`. Use `_` or `_headers` as a variable name to indicate that it won
't be used.
  test/action_client/middleware/response_parser_test.rb:54:9: Lint/UselessAssignment: Useless assignment to variable - `status`. Use `_` or `_status` as a variable name to indicate that it won't
be used.
  test/action_client/middleware/response_parser_test.rb:54:17: Lint/UselessAssignment: Useless assignment to variable - `headers`. Use `_` or `_headers` as a variable name to indicate that it won
't be used.
  test/action_client/response_test.rb:22:15: Lint/UselessAssignment: Useless assignment to variable - `headers`. Use `_` or `_headers` as a variable name to indicate that it won't be used.
  test/action_client/response_test.rb:31:15: Lint/UselessAssignment: Useless assignment to variable - `headers`. Use `_` or `_headers` as a variable name to indicate that it won't be used.
  test/action_client/response_test.rb:40:15: Lint/UselessAssignment: Useless assignment to variable - `headers`. Use `_` or `_headers` as a variable name to indicate that it won't be used.
standard: Run `standardrb --fix` to automatically fix some problems.
  test/integration/action_client/base_test.rb:52:48: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration/action_client/base_test.rb:160:48: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration/action_client/base_test.rb:181:48: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration/action_client/base_test.rb:204:48: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration/action_client/base_test.rb:227:48: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration/action_client/base_test.rb:431:48: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration/action_client/base_test.rb:459:48: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration/action_client/base_test.rb:484:48: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration/action_client/callbacks_test.rb:85:75: Style/Semicolon: Do not use semicolons to terminate expressions.
  test/integration/action_client/callbacks_test.rb:267:62: Style/Semicolon: Do not use semicolons to terminate expressions.
  test/integration/action_client/configuration_test.rb:11:49: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration/action_client/configuration_test.rb:25:49: Standard/SemanticBlocks: Prefer `{...}` over `do...end` for functional blocks.
  test/integration_test_case.rb:11:11: Style/EvalWithLocation: Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.

Notice: Disagree with these rules? While StandardRB is pre-1.0.0, feel free to submit suggestions to:
  https://github.com/testdouble/standard/issues/new
```

Incorporate standardrb into the CI Test Suite
===

To ensure that future linter violations are no longer added to the
codebase, execute `standardrb` as part of the GitHub Actions Continuous
Integration test suite.

