### PR TITLE
CI: Install Rails version based on Gemfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: "CI Tests"
 
-on: ["push", "pull_request"]
+on:
+  push:
+    branches: "main"
+  pull_request:
+    branches: "*"
 
 jobs:
   build:
@@ -9,9 +13,13 @@ jobs:
     runs-on: "ubuntu-latest"
 
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["2.6", "2.7"]
         rails: ["5.2", "6.0", "master"]
+        include:
+          - rails: "master"
+            continue-on-error: true
 
     env:
       RAILS_VERSION: "${{ matrix.rails }}"
@@ -34,6 +42,7 @@ jobs:
         key: bundle-${{ hashFiles('Gemfile.lock') }}
 
     - name: "Build and test"
+      continue-on-error: ${{ matrix.continue-on-error }}
       run: |
         bin/setup
         bin/rails test

--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,12 @@ gemspec
 rails_version = ENV.fetch("RAILS_VERSION", "6.0")
 
 if rails_version == "master"
-  rails_constraint = { github: "rails/rails" }
+  rails_constraint = {github: "rails/rails"}
 else
-  rails_constraint = "~> #{rails_version}.0"
+  rails_constraint = "#{rails_version}.0"
 end
+
+gem "rails", rails_constraint
 
 group :test do
   gem "minitest-around", require: "minitest/around/unit"

--- a/action_client.gemspec
+++ b/action_client.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", ">= 4.2.0"
+  spec.add_dependency "zeitwerk"
 end

--- a/lib/action_client/http_status_filter.rb
+++ b/lib/action_client/http_status_filter.rb
@@ -5,7 +5,13 @@ module ActionClient
     end
 
     def include?(matching_status)
-      status_codes.include? to_code(matching_status)
+      code = to_code(matching_status)
+
+      if status_codes.respond_to?(:cover?)
+        status_codes.cover? code
+      else
+        status_codes.include? code
+      end
     end
 
     private

--- a/lib/action_client/submittable_request.rb
+++ b/lib/action_client/submittable_request.rb
@@ -19,7 +19,7 @@ module ActionClient
     def submit_later(**options)
       @client.submission_job.set(options).perform_later(
         @client.class.name,
-        @client.action_name,
+        @client.action_name.to_s,
         *@action_arguments,
       )
     end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -19,7 +19,13 @@ require "action_client"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults (
+      if ENV["RAILS_VERSION"] == "master"
+        6.1
+      else
+        ENV.fetch("RAILS_VERSION", 6.0).to_f
+      end
+    )
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
@@ -27,4 +33,3 @@ module Dummy
     # the framework and any gems in your application.
   end
 end
-

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{ActiveSupport::Duration.hours(1)}"
   }
 
   # Show full error reports and disable caching.

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -165,7 +165,7 @@ module ActionClient
         end
       end
       article = Article.new("1", nil)
-      declare_template "article_client/destroy.json", <<~JS
+      declare_template "article_client/destroy.json.erb", <<~JS
       {"confirm": true}
       JS
 

--- a/test/integration/action_client/submit_later_test.rb
+++ b/test/integration/action_client/submit_later_test.rb
@@ -13,7 +13,7 @@ module ActionClient
 
     test "#submit_later enqueues a Job with arguments and options" do
       stub_request(:get, "https://example.com/special-ping?status=special")
-      request = MetricsClient.ping("special-ping", status: :special)
+      request = MetricsClient.ping("special-ping", status: "special")
 
       perform_enqueued_jobs { request.submit_later }
 
@@ -29,16 +29,16 @@ module ActionClient
     end
 
     test "#submit_later forwards options along when scheduling the ActiveJob::Job" do
-      MetricsClient.ping.submit_later(queue: "requests")
-
-      assert_enqueued_with job: ActionClient::SubmissionJob, queue: "requests"
+      assert_enqueued_with job: ActionClient::SubmissionJob, queue: "requests" do
+        MetricsClient.ping.submit_later(queue: "requests")
+      end
     end
 
     test "#submit_later enqueues a different job class" do
       with_submission_job MetricsClient, MetricsClientJob do
-        MetricsClient.ping.submit_later
-
-        assert_enqueued_with(job: MetricsClientJob)
+        assert_enqueued_with(job: MetricsClientJob) do
+          MetricsClient.ping.submit_later
+        end
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, our Continuous Integration test suite was not
being run against differing versions of Rails.

This commit resolves that by passing the `rails_constraint` to the `gem
"rails"` declaration, which we determine based on the value of the
`RAILS_VERSION` environment variable.

Additionally, for the sake of backwards compatibility with `rails@5.2`,
this commit also includes implementation fixes necessary to get the Test
Suite passing.