### PR TITLE
Construct Request body from raw template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for inferring `Content-Type` based on the extension of raw
+  templates (e.g. `articles_client/create.json`) (added by [@seanpdoyle[]])
+
 - Change development branch to `main` (added by [@seanpdoyle][])
 
 - Integrate with `ActiveJob` by declaring

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -165,7 +165,7 @@ module ActionClient
         end
       }
       article = Article.new("1", nil)
-      declare_template "article_client/destroy.json.erb", <<~JS
+      declare_template "article_client/destroy.json", <<~JS
         {"confirm": true}
       JS
 
@@ -246,6 +246,25 @@ module ActionClient
         {"response" => {"title" => "From Layout"}},
         JSON.parse(request.body.read)
       )
+    end
+
+    test "construacts a JSON request body from a raw template" do
+      client = declare_client("status_client") {
+        default url: "https://example.com"
+
+        def ping
+          post path: "/ping"
+        end
+      }
+      declare_template "status_client/ping.json", <<~JS
+        {"status": "healthy"}
+      JS
+
+      request = client.ping
+
+      assert_equal "https://example.com/ping", request.original_url
+      assert_equal "application/json", request.headers["Content-Type"]
+      assert_equal "healthy", JSON.parse(request.body.read).fetch("status")
     end
 
     test "constructs a request with the full URL passed as an option" do


### PR DESCRIPTION
When a template is declared without a handler extension (e.g.
`articles_client/create.json` instead of
`articles_client/create.json.erb`), use the template's file extension to
try and determine the appropriate `Content-Type`.