### PR TITLE
Declare assertions for ActiveJob integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `ActionClient::TestHelpers` module to support assertions about ActiveJob
+  integration (added by [@seanpdoyle][])
+
 - Add support for `except_status:` to omit execution of an `after_perform` hook
   for an `ActionClient::SubmissionJob` descendant (added by [@seanpdoyle][])
 

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -22,6 +22,7 @@ module ActionClient
       instance_accessor: true,
       default: ActionClient::SubmissionJob
 
+    attr_reader :action_arguments
     attr_reader :response
 
     class << self
@@ -203,8 +204,15 @@ module ActionClient
         @middleware,
         request.env,
         client: self,
-        action_arguments: @action_arguments,
         &block
+      )
+    end
+
+    def enqueue_job(**options)
+      submission_job.set(options).perform_later(
+        self.class.name,
+        action_name,
+        *action_arguments
       )
     end
 

--- a/lib/action_client/submittable_request.rb
+++ b/lib/action_client/submittable_request.rb
@@ -1,10 +1,11 @@
 module ActionClient
   class SubmittableRequest < ActionDispatch::Request
-    def initialize(stack, env, client:, action_arguments:, &block)
+    attr_reader :client
+
+    def initialize(stack, env, client:, &block)
       super(env)
       @stack = stack
       @client = client
-      @action_arguments = action_arguments
       @block = block
     end
 
@@ -16,11 +17,7 @@ module ActionClient
     alias submit_now submit
 
     def submit_later(**options)
-      @client.submission_job.set(options).perform_later(
-        @client.class.name,
-        @client.action_name.to_s,
-        *@action_arguments
-      )
+      client.enqueue_job(options)
     end
   end
 end

--- a/lib/action_client/test_helpers.rb
+++ b/lib/action_client/test_helpers.rb
@@ -1,0 +1,39 @@
+module ActionClient
+  module TestHelpers
+    include ActiveJob::TestHelper
+
+    def assert_enqueued_request(request, **options, &block)
+      client = request.client
+
+      assert_enqueued_with(
+        job: client.submission_job,
+        args: [client.class.name, client.action_name, *client.action_arguments],
+        **options,
+        &block
+      )
+    end
+
+    def assert_no_requests_enqueued(client_class = ActionClient::Base, **options, &block)
+      job_class = client_class.submission_job
+
+      assert_no_enqueued_jobs(only: job_class, **options, &block)
+    end
+
+    def assert_performed_request(request, **options, &block)
+      client = request.client
+
+      assert_performed_with(
+        job: client.submission_job,
+        args: [client.class.name, client.action_name, *client.action_arguments],
+        **options,
+        &block
+      )
+    end
+
+    def assert_no_performed_requests(client_class = ActionClient::Base, **options, &block)
+      job_class = client_class.submission_job
+
+      assert_no_performed_jobs(only: job_class, **options, &block)
+    end
+  end
+end

--- a/test/action_client_test.rb
+++ b/test/action_client_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class ActionClient::Test < ActiveSupport::TestCase
-  test "truth" do
-    assert_kind_of Module, ActionClient
-  end
-end

--- a/test/integration/action_client/active_job_assertions_test.rb
+++ b/test/integration/action_client/active_job_assertions_test.rb
@@ -1,0 +1,233 @@
+require "test_helper"
+require "active_job_test_case"
+
+module ActionClient
+  class ActiveJobAssertionsTestCase < ActiveJobTestCase
+    include ActionClient::TestHelpers
+    MetricsClient = Class.new(ActionClient::Base) {
+      def ping(name, **query)
+        get url: "https://example.com/ping?name=#{name}", query: query
+      end
+    }
+    MetricsClientJob = Class.new(ActionClient::SubmissionJob)
+
+    def self.test(*arguments, rails: 5.2, &block)
+      if Gem::Version.new(rails.to_s) <= Rails.gem_version
+        super(*arguments, &block)
+      else
+        super(*arguments) { pass }
+      end
+    end
+
+    def ignore_http_requests!
+      stub_request(:get, %r{example.com})
+    end
+  end
+
+  class AssertRequestEnqueuedTest < ActiveJobAssertionsTestCase
+    test "#assert_enqueued_request accepts a request", rails: 6.0 do
+      request = MetricsClient.ping("status", x: 1)
+
+      request.submit_later
+
+      assert_enqueued_request request
+    end
+
+    test "#assert_enqueued_request accepts a block" do
+      request = MetricsClient.ping("status", x: 1)
+
+      assert_enqueued_request(request) { request.submit_later }
+    end
+
+    test "#assert_enqueued_request accepts a options" do
+      request = MetricsClient.ping("status")
+
+      assert_enqueued_request(request, queue: "low_priority") do
+        request.submit_later(queue: "low_priority")
+      end
+    end
+
+    test "#assert_enqueued_request raises with a request", rails: 6.0 do
+      request = MetricsClient.ping("status", x: 1)
+
+      assert_raises ActiveSupport::TestCase::Assertion do
+        assert_enqueued_request(request)
+      end
+    end
+
+    test "#assert_enqueued_request raises from a block" do
+      request = MetricsClient.ping("status", x: 1)
+
+      assert_raises ActiveSupport::TestCase::Assertion do
+        assert_enqueued_request(request) {}
+      end
+    end
+  end
+
+  class AssertNoRequestsEnqueuedTest < ActiveJobAssertionsTestCase
+    test "#assert_no_requests_enqueued does not fail when a request is not made" do
+      assert_no_requests_enqueued
+    end
+
+    test "#assert_no_requests_enqueued accepts a block" do
+      assert_no_requests_enqueued { 1 + 1 }
+    end
+
+    test "#assert_no_requests_enqueued accepts a options", rails: 6.0 do
+      request = MetricsClient.ping("status")
+
+      assert_no_requests_enqueued(queue: "low_priority") do
+        request.submit_later(queue: "default")
+      end
+    end
+
+    test "#assert_no_requests_enqueued does not raise for the argument" do
+      with_submission_job MetricsClient, MetricsClientJob do
+        request = MetricsClient.ping("status")
+
+        request.submit_later
+
+        assert_raises ActiveSupport::TestCase::Assertion do
+          assert_no_requests_enqueued(MetricsClient)
+        end
+      end
+    end
+
+    test "#assert_no_requests_enqueued raises without a block" do
+      request = MetricsClient.ping("status")
+
+      request.submit_later
+
+      assert_raises ActiveSupport::TestCase::Assertion do
+        assert_no_requests_enqueued
+      end
+    end
+
+    test "#assert_no_requests_enqueued raises from a block" do
+      request = MetricsClient.ping("status")
+
+      assert_raises ActiveSupport::TestCase::Assertion do
+        assert_no_requests_enqueued { request.submit_later }
+      end
+    end
+  end
+
+  class AssertRequestPerformedTest < ActiveJobAssertionsTestCase
+    test "#assert_performed_request accepts a request", rails: 6.0 do
+      ignore_http_requests!
+      perform_enqueued_jobs do
+        request = MetricsClient.ping("status")
+
+        request.submit_later
+
+        assert_performed_request request
+      end
+    end
+
+    test "#assert_performed_request accepts a block" do
+      ignore_http_requests!
+      request = MetricsClient.ping("status")
+
+      assert_performed_request(request) { request.submit_later }
+    end
+
+    test "#assert_performed_request accepts options", rails: 6.0 do
+      ignore_http_requests!
+      perform_enqueued_jobs do
+        request = MetricsClient.ping("status")
+        request.submit_later(queue: "low_priority")
+
+        assert_performed_request(request, queue: "low_priority")
+      end
+    end
+
+    test "#assert_enqueued_request raises with a request", rails: 6.0 do
+      perform_enqueued_jobs do
+        request = MetricsClient.ping("status")
+
+        assert_raises ActiveSupport::TestCase::Assertion do
+          assert_performed_request(request)
+        end
+      end
+    end
+
+    test "#assert_enqueued_request raises with a block" do
+      request = MetricsClient.ping("status")
+
+      assert_raises ActiveSupport::TestCase::Assertion do
+        assert_performed_request(request) {}
+      end
+    end
+
+    test "#assert_enqueued_request raises with options", rails: 6.0 do
+      ignore_http_requests!
+      perform_enqueued_jobs do
+        request = MetricsClient.ping("status")
+
+        request.submit_later(queue: "default")
+
+        exception = assert_raises(ActiveSupport::TestCase::Assertion) {
+          assert_performed_request(request, queue: "low_priority")
+        }
+        assert_includes exception.message, "low_priority"
+      end
+    end
+  end
+
+  class AssertNoPerformedRequestsTest < ActiveJobAssertionsTestCase
+    test "#assert_no_performed_requests does not fail when no requests are performed" do
+      perform_enqueued_jobs do
+        assert_no_performed_requests
+      end
+    end
+
+    test "#assert_no_performed_requests accepts a block" do
+      perform_enqueued_jobs do
+        assert_no_performed_requests { 1 + 1 }
+      end
+    end
+
+    test "#assert_no_performed_requests accepts a options", rails: 6.0 do
+      request = MetricsClient.ping("status")
+
+      assert_no_performed_requests(queue: "low_priority") do
+        request.submit_later(queue: "default")
+      end
+    end
+
+    test "#assert_no_performed_requests does not raise for the argument class" do
+      ignore_http_requests!
+      with_submission_job MetricsClient, MetricsClientJob do
+        request = MetricsClient.ping("status")
+
+        perform_enqueued_jobs { request.submit_later }
+
+        assert_raises ActiveSupport::TestCase::Assertion do
+          assert_no_performed_requests(MetricsClient)
+        end
+      end
+    end
+
+    test "#assert_no_performed_requests raises without a block" do
+      ignore_http_requests!
+      request = MetricsClient.ping("status")
+
+      perform_enqueued_jobs { request.submit_later }
+
+      assert_raises ActiveSupport::TestCase::Assertion do
+        assert_no_performed_requests
+      end
+    end
+
+    test "#assert_no_performed_requests raises from a block" do
+      ignore_http_requests!
+      perform_enqueued_jobs do
+        request = MetricsClient.ping("status")
+
+        assert_raises ActiveSupport::TestCase::Assertion do
+          assert_no_performed_requests { request.submit_later }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Declare assertions for ActiveJob integration
===

To integrate `ActionClient`-provided assertions into your tests, include
the `ActionClient::TestHelpers` module:

```ruby
class ArticlesControllerTest < ActionDispatch::IntegrationTest
  include ActionClient::TestHelpers

  # ...
end
```

ActiveJob Assertions
---

`ActionClient` provides a collection of assertions to verify that
requests processed by invoking `#submit_later` are enqueued or
performed.

Inspired by the [Rails-provided `ActiveJob::TestHelper`
assertions][ActiveJob::TestHelper], `ActionClient` assertions verify
that a request has been performed, or been enqueued to be performed by a
background job.

When [`config.active_job.queue_adapter = :test`][test-adapter]:

* `assert_enqueued_request(request, **options, &block)`
* `assert_no_enqueued_requests(client_class, **options, &block)`

```ruby
test "#create enqueues a request to the Articles API" do
  post articles_path(params: { article: { title: "Hello, World" } })

  assert_enqueued_request ArticlesClient.create(title: "Hello, World"))
end

test "#create enqueues a request to the Articles API" do
  assert_enqueued_request ArticlesClient.create(title: "Hello, World")) do
    post articles_path(params: { article: { title: "Hello, World" } })
  end
end

test "#create does not enqueue a request to the Articles API when invalid" do
  post articles_path(params: { article: { title: "" } })

  assert_no_enqueued_requests ArticlesClient
end

test "#create does not enqueue a request to the Articles API when invalid" do
  assert_no_enqueued_requests ArticlesClient do
    post articles_path(params: { article: { title: "" } })
  end
end
```

When [`config.active_job.queue_adapter = :inline`][inline-adapter]:

* `assert_performed_request(request, **options, &block)`
* `assert_no_performed_requests(client_class, **options, &block)`

```ruby
test "#create enqueues a request to the Articles API" do
  perform_enqueued_jobs do
    post articles_path(params: { article: { title: "Hello, World" } })

    assert_performed_request ArticlesClient.create(title: "Hello, World"))
  end
end

test "#create enqueues a request to the Articles API" do
    assert_performed_request ArticlesClient.create(title: "Hello, World")) do
      post articles_path(params: { article: { title: "Hello, World" } })
    end
  end
end

test "#create does not enqueue a request to the Articles API when invalid" do
  perform_enqueued_jobs do
    post articles_path(params: { article: { title: "" } })

    assert_no_performed_requests ArticlesClient
  end
end

test "#create does not enqueue a request to the Articles API when invalid" do
  assert_no_performed_requests ArticlesClient do
    post articles_path(params: { article: { title: "" } })
  end
end
```

[ActiveJob::TestHelper]: https://api.rubyonrails.org/classes/ActiveJob/TestHelper.html
[test-adapter]: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/TestAdapter.html
[inline-adapter]: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/InlineAdapter.html

Testing
===

ActiveJob assertions like `assert_enqueued_with` [_only_ accept blocks
in Rails 5.2][assert_enqueued_with-5.2], and [can be invoked after the
fact in Rails 6.0][assert_enqueued_with-6.0].

This commit's test files' coverage is a mixture of both styles.

[assert_enqueued_with-5.2]: https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html#method-i-assert_enqueued_with
[assert_enqueued_with-6.0]: https://api.rubyonrails.org/v6.0/classes/ActiveJob/TestHelper.html#method-i-assert_enqueued_with

