### PR TITLE
Introduce a Rails generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,28 @@ end
 [test-adapter]: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/TestAdapter.html
 [inline-adapter]: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/InlineAdapter.html
 
+## Generator
+
+Action Client comes with a Rails generator to set up the main files you will
+need for your client. To use the generator, run:
+
+```sh
+bin/rails generate action_client NAME [action action action]
+```
+
+For example:
+
+```sh
+bin/rails generate action_client articles create show
+```
+
+This will create the `ArticlesClient` class, as well as the view directory, the
+config file, and the `ArticlesClientPreview` class. Both the client and preview
+classes will have methods defined for the `create` and `show` actions.
+
+`NAME` can be passed in CamelCase or snake_case, with or without the "client"
+prefix: e.g. "articles, "Articles", "articles_client", or "ArticlesClient".
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/lib/generators/action_client/USAGE
+++ b/lib/generators/action_client/USAGE
@@ -1,7 +1,7 @@
 Description:
 ============
     Generates a new action client along with its view directory, config file,
-    and preview class. Accepts the mailer name, either CamelCased or
+    and preview class. Accepts the client name, either CamelCased or
     under_scored, and an optional list of actions as arguments.
 
 Example:

--- a/lib/generators/action_client/USAGE
+++ b/lib/generators/action_client/USAGE
@@ -1,0 +1,15 @@
+Description:
+============
+    Generates a new action client along with its view directory, config file,
+    and preview class. Accepts the mailer name, either CamelCased or
+    under_scored, and an optional list of actions as arguments.
+
+Example:
+========
+    bin/rails generate action_client articles create
+
+    creates an action_client class, view directory, config file, and preview class
+        Client:     app/clients/articles_client.rb
+        View:       app/views/articles_client/create.json.erb
+        Config:     config/clients/articles.yml
+        Preview:    test/clients/previews/articles_client_preview.rb

--- a/lib/generators/action_client/action_client_generator.rb
+++ b/lib/generators/action_client/action_client_generator.rb
@@ -1,0 +1,54 @@
+class ActionClientGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path("templates", __dir__)
+
+  argument :actions, type: :array, default: [], banner: "method method"
+
+  def check_class_collision
+    class_collisions(
+      "#{class_name}Client",
+      "#{class_name}ClientPreview"
+    )
+  end
+
+  def create_action_client_file
+    template_if_missing "application_client.rb", "app/clients/application_client.rb"
+    template "action_client.rb", File.join("app/clients", class_path, "#{file_name}_client.rb")
+  end
+
+  def create_view_dir
+    empty_directory_with_keep_file(
+      File.join("app/views", class_path, "#{file_name}_client")
+    )
+  end
+
+  def create_config_file
+    template "config.yml", File.join("config/clients", class_path, "#{file_name}.yml")
+  end
+
+  def create_preview_file
+    template "preview.rb", File.join("test/clients/previews", class_path, "#{file_name}_client_preview.rb")
+  end
+
+  private
+
+  def file_name
+    @_file_name ||= super.sub(/_client\z/i, "")
+  end
+
+  def template_if_missing(source, target)
+    in_root do
+      if behavior == :invoke && !File.exist?(target)
+        template source, target
+      end
+    end
+  end
+
+  def empty_directory_with_keep_file(destination)
+    empty_directory(destination)
+    keep_file(destination)
+  end
+
+  def keep_file(destination)
+    create_file("#{destination}/.keep")
+  end
+end

--- a/lib/generators/action_client/templates/action_client.rb.tt
+++ b/lib/generators/action_client/templates/action_client.rb.tt
@@ -1,0 +1,7 @@
+class <%= class_name %>Client < ApplicationClient
+<% actions.each do |action| -%>
+  def <%= action %>
+  end
+<%= "\n" unless action == actions.last -%>
+<% end -%>
+end

--- a/lib/generators/action_client/templates/application_client.rb.tt
+++ b/lib/generators/action_client/templates/application_client.rb.tt
@@ -1,0 +1,3 @@
+class ApplicationClient < ActionClient::Base
+  abstract!
+end

--- a/lib/generators/action_client/templates/config.yml.tt
+++ b/lib/generators/action_client/templates/config.yml.tt
@@ -1,0 +1,11 @@
+default: &default
+  url: "https://example.com/<%= file_name %>"
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/lib/generators/action_client/templates/preview.rb.tt
+++ b/lib/generators/action_client/templates/preview.rb.tt
@@ -1,0 +1,8 @@
+class <%= class_name %>ClientPreview < ActionClient::Preview
+<% actions.each do |action| -%>
+  def <%= action %>
+    <%= class_name %>Client.<%= action %>
+  end
+<%= "\n" unless action == actions.last -%>
+<% end -%>
+end

--- a/test/generators/action_client_generator_test.rb
+++ b/test/generators/action_client_generator_test.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+require "generators/action_client/action_client_generator"
+
+class ActionClientGeneratorTest < Rails::Generators::TestCase
+  tests ActionClientGenerator
+  destination Rails.root.join("tmp/generators")
+  setup :prepare_destination
+
+  test "generator creates client" do
+    run_generator ["example"]
+
+    assert_file "app/clients/example_client.rb" do |client|
+      assert_match(/class ExampleClient < ApplicationClient/, client)
+    end
+  end
+
+  test "generator creates client when passed the _client prefix" do
+    run_generator ["example_client"]
+
+    assert_file "app/clients/example_client.rb" do |client|
+      assert_match(/class ExampleClient < ApplicationClient/, client)
+    end
+  end
+
+  test "generator creates client with the provided actions" do
+    run_generator ["example", "create", "show"]
+
+    assert_file "app/clients/example_client.rb" do |client|
+      assert_match(/class ExampleClient < ApplicationClient/, client)
+      assert_match(/  def create/, client)
+      assert_match(/  def show/, client)
+    end
+  end
+
+  test "generator creates ApplicationClient" do
+    run_generator ["example"]
+
+    assert_file "app/clients/application_client.rb" do |client|
+      assert_match(/class ApplicationClient < ActionClient::Base/, client)
+    end
+  end
+
+  test "generator does not write over ApplicationClient if it already exists" do
+    run_generator ["example"]
+    stdout = run_generator ["example"]
+
+    assert_no_match(%r{identical  app/clients/application_client.rb}, stdout)
+  end
+
+  test "destroy does not remove ApplicationClient" do
+    run_generator ["example"], behavior: :invoke
+    run_generator ["example"], behavior: :revoke
+
+    assert_file "app/clients/application_client.rb" do |client|
+      assert_match(/class ApplicationClient < ActionClient::Base/, client)
+    end
+  end
+
+  test "generator creates view directory" do
+    run_generator ["example"]
+
+    assert_file("app/views/example_client/.keep")
+  end
+
+  test "generator creates config file" do
+    run_generator ["example"]
+
+    assert_file "config/clients/example.yml" do |client|
+      assert_match(%r{  url: "https://example.com/example"}, client)
+    end
+  end
+
+  test "generator creates preview" do
+    run_generator ["example"]
+
+    assert_file "test/clients/previews/example_client_preview.rb" do |client|
+      assert_match(/class ExampleClientPreview < ActionClient::Preview/, client)
+    end
+  end
+
+  test "generator creates preview with the provided actions" do
+    run_generator ["example", "create", "show"]
+
+    assert_file "test/clients/previews/example_client_preview.rb" do |client|
+      assert_match(/class ExampleClientPreview < ActionClient::Preview/, client)
+      assert_match(/  def create/, client)
+      assert_match(/    ExampleClient.create/, client)
+      assert_match(/  def show/, client)
+      assert_match(/    ExampleClient.show/, client)
+    end
+  end
+
+  test "check class collision" do
+    Object.send :const_set, :ExampleClient, Class.new
+    stderr = capture(:stderr) { run_generator ["example"] }
+    assert_match(/The name 'ExampleClient' is either already used in your application or reserved/, stderr)
+  ensure
+    Object.send :remove_const, :ExampleClient
+  end
+
+  test "check preview class collision" do
+    Object.send :const_set, :ExampleClientPreview, Class.new
+    stderr = capture(:stderr) { run_generator ["example"] }
+    assert_match(/The name 'ExampleClientPreview' is either already used in your application or reserved/, stderr)
+  ensure
+    Object.send :remove_const, :ExampleClientPreview
+  end
+end


### PR DESCRIPTION
Closes https://github.com/thoughtbot/action_client/issues/6

This commit introduces the action_client generator (started with the
rails [generator generator]).

It is inspired by the Action Mailer generators, including the [Mailer
generator], [Test and preview generator], and [View generator].

The generator can be run within a Rails project with

```
bin/rails generate action_client articles create show
```

This will create the ArticlesClient class, as well as the view directory
with a keep file, a config file, and an ArticlesClientPreview for
testing your client.

The client name can be passed CamelCased or under_scored, with or
without the client prefix: "articles", "Articles", "articles_client",
or "ArticlesClient".

The client's actions may be passed as additional arguments. These will
be used to define methods in the client and preview classes.

[generator generator]: https://edgeguides.rubyonrails.org/generators.html#creating-generators-with-generators
[Mailer generator]: https://github.com/rails/rails/tree/master/actionmailer/lib/rails/generators/mailer
[Test and preview generator]: https://github.com/rails/rails/tree/master/railties/lib/rails/generators/test_unit/mailer
[View generator]: https://github.com/rails/rails/tree/master/railties/lib/rails/generators/erb/mailer