### PR TITLE
Declare Constants in test suite

### DIFF
--- a/test/active_job_test_case.rb
+++ b/test/active_job_test_case.rb
@@ -3,14 +3,5 @@ require "integration_test_case"
 module ActionClient
   class ActiveJobTestCase < ActionClient::IntegrationTestCase
     include ActiveJob::TestHelper
-
-    def with_submission_job(client_class, job_class, &block)
-      original_job_class = client_class.submission_job
-      client_class.submission_job = job_class
-
-      block.call
-    ensure
-      client_class.submission_job = original_job_class
-    end
   end
 end

--- a/test/integration/action_client/active_job_test.rb
+++ b/test/integration/action_client/active_job_test.rb
@@ -3,44 +3,46 @@ require "active_job_test_case"
 
 module ActionClient
   class ActiveJobTest < ActionClient::ActiveJobTestCase
-    # freeze so that test cases don't accidentally leak state across classes
-    MetricsClientJob = Class.new(ActionClient::SubmissionJob).freeze
-    MetricsClient = Class.new(ActionClient::Base) {
-      def ping
-        get url: "https://example.com/ping"
-      end
-    }
-
     class AfterPerformWithoutOptionsTest < ActiveJobTest
-      MetricsClientJob = Class.new(ActionClient::SubmissionJob)
-
-      setup { MetricsClientJob.reset_callbacks(:perform) }
-
       test ".after_perform without options always executes" do
+        response = nil
+        job = declare_job { after_perform { response = self.response } }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
         stub_request(:get, "https://example.com/ping").to_return(
           headers: {"Content-Type": "application/json"},
           body: {status: "success"}.to_json
         )
-        status, headers, body = []
-        MetricsClientJob.after_perform { status, headers, body = *response }
 
-        with_submission_job MetricsClient, MetricsClientJob do
-          perform_enqueued_jobs { MetricsClient.ping.submit_later }
-        end
+        perform_enqueued_jobs { client.ping.submit_later }
 
-        assert_equal 200, status
-        assert_equal "application/json", headers["Content-Type"]
-        assert_equal "success", body["status"]
+        assert_equal 200, response.status
+        assert_equal "application/json", response.headers["Content-Type"]
+        assert_equal "success", response.body["status"]
       end
     end
 
     class AfterPerformWithStatusOptionsTest < ActiveJobTest
-      MetricsClientJob = Class.new(ActionClient::SubmissionJob)
-
-      setup { MetricsClientJob.reset_callbacks(:perform) }
-
       test ".after_perform executes a block when the status codes match only_status:" do
-        status, headers, body = []
+        response = nil
+        job = declare_job {
+          after_perform(only_status: 400..599) do
+            response = self.response
+            retry_job
+          end
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
         stub_request(:get, "https://example.com/ping")
           .to_return(
             headers: {"Content-Type": "application/json"},
@@ -48,24 +50,31 @@ module ActionClient
             status: 500
           ).times(1)
           .then.to_return(status: 200)
-        MetricsClientJob.after_perform(only_status: 400..599) do
-          status, headers, body = *response
-          retry_job
-        end
 
-        with_submission_job MetricsClient, MetricsClientJob do
-          perform_enqueued_jobs { MetricsClient.ping.submit_later }
-        end
+        perform_enqueued_jobs { client.ping.submit_later }
 
-        assert_performed_jobs(2, only: MetricsClientJob)
+        assert_performed_jobs(2, only: job)
         assert_requested :get, "https://example.com/ping", times: 2
-        assert_equal 500, status
-        assert_equal "application/json", headers["Content-Type"]
-        assert_equal "error", body["status"]
+        assert_equal 500, response.status
+        assert_equal "application/json", response.headers["Content-Type"]
+        assert_equal "error", response.body["status"]
       end
 
       test ".after_perform executes a block when the status codes does not match except_status:" do
-        status, headers, body = []
+        response = nil
+        job = declare_job {
+          after_perform(except_status: 200) do
+            response = self.response
+            retry_job
+          end
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
         stub_request(:get, "https://example.com/ping")
           .to_return(
             headers: {"Content-Type": "application/json"},
@@ -73,47 +82,51 @@ module ActionClient
             status: 500
           ).times(1)
           .then.to_return(status: 200)
-        MetricsClientJob.after_perform(except_status: 200) do
-          status, headers, body = *response
-          retry_job
-        end
 
-        with_submission_job MetricsClient, MetricsClientJob do
-          perform_enqueued_jobs { MetricsClient.ping.submit_later }
-        end
+        perform_enqueued_jobs { client.ping.submit_later }
 
-        assert_performed_jobs(2, only: MetricsClientJob)
+        assert_performed_jobs(2, only: job)
         assert_requested :get, "https://example.com/ping", times: 2
-        assert_equal 500, status
-        assert_equal "application/json", headers["Content-Type"]
-        assert_equal "error", body["status"]
+        assert_equal 500, response.status
+        assert_equal "application/json", response.headers["Content-Type"]
+        assert_equal "error", response.body["status"]
       end
 
       test ".after_perform skips execution of blocks when the status code does not match only_status:" do
-        stub_request(:get, "https://example.com/ping").to_return(status: 200)
-        MetricsClientJob.after_perform(only_status: 400..599) { raise }
+        job = declare_job { after_perform(only_status: 400..599) { raise } }
+        client = declare_client {
+          self.submission_job = job
 
-        with_submission_job MetricsClient, MetricsClientJob do
-          perform_enqueued_jobs { MetricsClient.ping.submit_later }
-        end
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping").to_return(status: 200)
+
+        perform_enqueued_jobs { client.ping.submit_later }
 
         assert_no_enqueued_jobs
       end
 
       test ".after_perform skips execution of blocks when the status code does matches except_status:" do
-        stub_request(:get, "https://example.com/ping").to_return(status: 200)
-        MetricsClientJob.after_perform(except_status: 200) { raise }
+        job = declare_job { after_perform(except_status: 200) { raise } }
+        client = declare_client {
+          self.submission_job = job
 
-        with_submission_job MetricsClient, MetricsClientJob do
-          perform_enqueued_jobs { MetricsClient.ping.submit_later }
-        end
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping").to_return(status: 200)
+
+        perform_enqueued_jobs { client.ping.submit_later }
 
         assert_no_enqueued_jobs
       end
 
       test ".after_perform raises when both only_status: and except_status: are present" do
         exception = assert_raises {
-          MetricsClientJob.after_perform(except_status: 200, only_status: 200) { raise }
+          declare_job { after_perform(except_status: 200, only_status: 200) { raise } }
         }
 
         assert_includes exception.message, "except_status:"

--- a/test/integration/action_client/base_test.rb
+++ b/test/integration/action_client/base_test.rb
@@ -49,7 +49,7 @@ module ActionClient
     end
 
     test "constructs a POST request with a JSON body declared with instance variables" do
-      client = declare_client("article_client") {
+      client = declare_client("ArticleClient") {
         default url: "https://example.com"
 
         def create(article:)
@@ -157,7 +157,7 @@ module ActionClient
     end
 
     test "constructs a DELETE request with a JSON body template" do
-      client = declare_client("article_client") {
+      client = declare_client("ArticleClient") {
         default url: "https://example.com"
 
         def destroy(article:)
@@ -178,7 +178,7 @@ module ActionClient
     end
 
     test "constructs a PUT request with a JSON body declared with locals" do
-      client = declare_client("article_client") {
+      client = declare_client("ArticleClient") {
         default url: "https://example.com"
 
         def update(article:)
@@ -201,7 +201,7 @@ module ActionClient
     end
 
     test "constructs a PATCH request with an XML body declared with locals" do
-      client = declare_client("article_client") {
+      client = declare_client("ArticleClient") {
         default url: "https://example.com"
 
         def update(article:)
@@ -224,7 +224,7 @@ module ActionClient
     end
 
     test "constructs a request with a body wrapped by a layout" do
-      client = declare_client("article_client") {
+      client = declare_client("ArticleClient") {
         def create(article:)
           post \
             layout: "article_client",
@@ -249,7 +249,7 @@ module ActionClient
     end
 
     test "construacts a JSON request body from a raw template" do
-      client = declare_client("status_client") {
+      client = declare_client("StatusClient") {
         default url: "https://example.com"
 
         def ping
@@ -459,7 +459,7 @@ module ActionClient
     end
 
     test "#submit makes an appropriate HTTP request" do
-      client = declare_client("article_client") {
+      client = declare_client("ArticleClient") {
         default url: "https://example.com"
 
         def create(article:)
@@ -487,7 +487,7 @@ module ActionClient
     end
 
     test "#submit parses a JSON response based on the `Content-Type`" do
-      client = declare_client("article_client") {
+      client = declare_client("ArticleClient") {
         default url: "https://example.com"
 
         def create(article:)
@@ -513,7 +513,7 @@ module ActionClient
 
     test "#submit parses a JSON-LD response based on the `Content-Type`" do
       title = "Article title"
-      client = declare_client("article_client") {
+      client = declare_client("ArticleClient") {
         default url: "https://example.com"
 
         def create(title:)
@@ -538,7 +538,7 @@ module ActionClient
     end
 
     test "#submit parses an XML response based on the `Content-Type`" do
-      client = declare_client("article_client") {
+      client = declare_client("ArticleClient") {
         default url: "https://example.com"
 
         def create(article:)

--- a/test/integration/action_client/configuration_test.rb
+++ b/test/integration/action_client/configuration_test.rb
@@ -4,13 +4,13 @@ require "integration_test_case"
 module ActionClient
   class ConfigurationTestCase < ActionClient::IntegrationTestCase
     test "default headers will cascade down the inheritance hierarchy" do
-      application_client = declare_client("application_client") {
+      declare_client "ApplicationClient" do
         default headers: {
           "X-Special": "abc123",
           "Content-Type": "text/plain"
         }
-      }
-      client = declare_client(inherits: application_client) {
+      end
+      client = declare_client(inherits: ApplicationClient) {
         default headers: {
           "Content-Type": "application/json"
         }
@@ -31,7 +31,7 @@ module ActionClient
         test:
           url: "https://example.com"
       YAML
-      client = declare_client("articles_client") {
+      client = declare_client("ArticlesClient") {
         default url: configuration.url
 
         def all
@@ -45,7 +45,7 @@ module ActionClient
     end
 
     test "defaults to an empty configuration when a file is not present" do
-      client = declare_client("articles_client") {
+      client = declare_client("ArticlesClient") {
         default url: configuration.url || "https://example.com"
 
         def all

--- a/test/integration/action_client/submit_later_test.rb
+++ b/test/integration/action_client/submit_later_test.rb
@@ -3,17 +3,14 @@ require "active_job_test_case"
 
 module ActionClient
   class SubmitLaterTest < ActionClient::ActiveJobTestCase
-    MetricsClient = Class.new(ActionClient::Base) {
-      def ping(path = "ping", **options)
-        get url: "https://example.com/#{path}", query: options
-      end
-    }
-
-    MetricsClientJob = Class.new(ActionClient::SubmissionJob)
-
     test "#submit_later enqueues a Job with arguments and options" do
+      client = declare_client {
+        def ping(path = "ping", **options)
+          get url: "https://example.com/#{path}", query: options
+        end
+      }
       stub_request(:get, "https://example.com/special-ping?status=special")
-      request = MetricsClient.ping("special-ping", status: "special")
+      request = client.ping("special-ping", status: "special")
 
       perform_enqueued_jobs { request.submit_later }
 
@@ -22,24 +19,40 @@ module ActionClient
 
     test "#submit_later enqueues an ActiveJob::Job to execute the request" do
       stub_request(:get, "https://example.com/ping")
+      client = declare_client {
+        def ping
+          get url: "https://example.com/ping"
+        end
+      }
 
-      perform_enqueued_jobs { MetricsClient.ping.submit_later }
+      perform_enqueued_jobs { client.ping.submit_later }
 
       assert_requested :get, "https://example.com/ping", times: 1
     end
 
     test "#submit_later forwards options along when scheduling the ActiveJob::Job" do
+      client = declare_client {
+        def ping
+          get url: "https://example.com/ping"
+        end
+      }
+
       assert_enqueued_with job: ActionClient::SubmissionJob, queue: "requests" do
-        MetricsClient.ping.submit_later(queue: "requests")
+        client.ping.submit_later(queue: "requests")
       end
     end
 
     test "#submit_later enqueues a different job class" do
-      with_submission_job MetricsClient, MetricsClientJob do
-        assert_enqueued_with(job: MetricsClientJob) do
-          MetricsClient.ping.submit_later
+      job = declare_job
+      client = declare_client {
+        self.submission_job = job
+
+        def ping
+          get url: "https://example.com/ping"
         end
-      end
+      }
+
+      assert_enqueued_with(job: job) { client.ping.submit_later }
     end
   end
 end


### PR DESCRIPTION
The majority of the test suite's coverage does not rely on a
`ActionClient::Base` descendant or an `ActionClient::SubmissionJob`
descendant being declared as a constant.

For others, the constant itself is unimportant, but the Client's
[`controller_path` method][controller_path] reflexively resolves the
path based on the class name. For example, `ArticleClient` will resolve
to `article_client`.

For some tests, the constant _must_ exist. For example, when serializing
the request to the `ActionClient::SubmissionJob`, the classes cannot be
anonymously declared.

To ensure those tests can function, this commit restructures the
`declare_client` helper to set and unset constants, ensuring they're
unset between tests. Additionally, add the `declare_job` helper to
declare `ActionClient::SubmissionJob` descendants.

[controller_path]: https://api.rubyonrails.org/classes/AbstractController/Base.html#method-c-controller_path