### PR TITLE
Set Client defaults based on configuration values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Implicitly call `default` with `url:` and `headers:` declarations from a
+  client's `config/clients` YAML file (added by [@seanpdoyle][])
+
 - Add `ActionClient::TestHelpers` module to support assertions about ActiveJob
   integration (added by [@seanpdoyle][])
 

--- a/README.md
+++ b/README.md
@@ -313,10 +313,10 @@ Default values can be overridden on a request-by-request basis.
 When a default `url:` key is specified, a request's full URL will be built by
 joining the base `default url: ...` value with the request's `path:` option.
 
-In this example, `ArticlesClient.configuration` will read directly from the
-environment-aware `config/clients/articles.yml` file.
+### Configuring your clients in YAML
 
-Consider the following configuration:
+Consider the following configuration file declared at
+`config/clients/articles.yml`:
 
 ```yaml
 # config/clients/articles.yml
@@ -334,13 +334,19 @@ production:
   url: "https://example.com"
 ```
 
-Then from the client class, read those values directly from `configuration`:
+In this example, the `ArticlesClient.configuration` will read directly from the
+environment-aware `config/clients/articles.yml` file.
+
+The client class can access those values directly from `.configuration`:
 
 ```ruby
 class ArticlesClient < ActionClient::Base
   default url: configuration.url
 end
 ```
+
+If there are `url:` or `headers:` declarations in the configuration file, they
+will implicitly be forwarded as arguments to `default`.
 
 When a matching configuration file does not exist,
 `ActionClient::Base.configuration` returns an empty instance of

--- a/lib/action_client/base.rb
+++ b/lib/action_client/base.rb
@@ -27,7 +27,7 @@ module ActionClient
 
     class << self
       def inherited(descendant)
-        descendant.defaults = defaults.dup
+        descendant.defaults = defaults.with_defaults(descendant.configuration)
         descendant.middleware = middleware.dup
       end
 
@@ -99,7 +99,7 @@ module ActionClient
       end
 
       def client_name
-        controller_path.gsub("_client", "")
+        controller_path.to_s.delete_suffix("_client")
       end
 
       def respond_to?(method, *arguments)
@@ -127,6 +127,10 @@ module ActionClient
     def process(action_name, *arguments)
       @action_arguments = arguments
       super
+    end
+
+    def configuration
+      self.class.configuration
     end
 
     def id

--- a/test/integration/action_client/configuration_test.rb
+++ b/test/integration/action_client/configuration_test.rb
@@ -57,5 +57,27 @@ module ActionClient
 
       assert_equal "https://example.com/articles", request.url
     end
+
+    test "declares defaults from configuration when inherited" do
+      declare_config "clients/articles.yml", <<~YAML
+        test:
+          headers:
+            X-Special-Key: "abc123"
+          url: "https://example.com"
+      YAML
+      declare_client("ApplicationClient", inherits: ActionClient::Base)
+      class ::ArticlesClient < ApplicationClient
+        def all
+          get path: "articles"
+        end
+      end
+
+      request = ArticlesClient.all
+
+      assert_equal "https://example.com/articles", request.url
+      assert_equal "abc123", request.headers["X-Special-Key"]
+    ensure
+      Object.send :remove_const, "ArticlesClient"
+    end
   end
 end


### PR DESCRIPTION
When an `ActionClient::Base` descendant is declared, and that class has
a corresponding configuration file, automatically load the
configuration's `url:` and `headers:` values as that class' default
`url` and `headers` values.