### PR TITLE
Integrate with ActiveJob retry_on and discard_on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Declare `ActionClient::SubmissionJob.discard_on` to proxy to the `ActiveJob`
+  version (added by [@seanpdoyle][])
+
 - Declare `ActionClient::SubmissionJob.retry_on` to proxy to the `ActiveJob`
   version (added by [@seanpdoyle][])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Declare `ActionClient::SubmissionJob.retry_on` to proxy to the `ActiveJob`
+  version (added by [@seanpdoyle][])
+
 - Implicitly call `default` with `url:` and `headers:` declarations from a
   client's `config/clients` YAML file (added by [@seanpdoyle][])
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,27 @@ end
 
 Within the block, the Rack triplet is available as `response`.
 
+Similarly, to automatically retry jobs matching a single HTTP Status or a
+collection of HTTP Status Codes, declare a `retry_on` block:
+
+```ruby
+# app/jobs/articles_client_job.rb
+class ArticlesClientJob < ActionClient::SubmissionJob
+  retry_on except_status: 200, queue: "low_priority"
+end
+```
+
+Under the hood, this method declares a [`retry_on` block][retry_on], so you can
+mix and match `except_status:` and `only_status:` options with the other
+arguments `retry_on` accepts:
+
+```ruby
+# app/jobs/articles_client_job.rb
+class ArticlesClientJob < ActionClient::SubmissionJob
+  retry_on Net::OpenTimeout, except_status: 200, queue: "low_priority"
+end
+```
+
 Next, configure your client class to enqueue jobs with that class:
 
 ```ruby
@@ -267,6 +288,7 @@ The `ActionClient::SubmissionJob` provides an extended version of
 option, to serve as a guard clause filter.
 
 [after_perform]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
+[retry_on]: https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-retry_on
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ end
 
 Within the block, the Rack triplet is available as `response`.
 
+**`retry_on`**
+
 Similarly, to automatically retry jobs matching a single HTTP Status or a
 collection of HTTP Status Codes, declare a `retry_on` block:
 
@@ -275,6 +277,31 @@ class ArticlesClientJob < ActionClient::SubmissionJob
 end
 ```
 
+**`discard_on`**
+
+Similarly, to skip retrying jobs matching a single HTTP Status or a collection
+of HTTP Status Codes, declare a `discard_on` block:
+
+```ruby
+# app/jobs/articles_client_job.rb
+class ArticlesClientJob < ActionClient::SubmissionJob
+  retry_on except_status: 200, queue: "low_priority"
+  discard_on only_status: 422
+end
+```
+
+Under the hood, this method declares a [`discard_on` block][discard_on], so you
+can mix and match `except_status:` and `only_status:` options with the other
+arguments `discard_on` accepts:
+
+```ruby
+# app/jobs/articles_client_job.rb
+class ArticlesClientJob < ActionClient::SubmissionJob
+  retry_on Net::OpenTimeout
+  discard_on Articles::Api::InvalidError, only_status: 422
+end
+```
+
 Next, configure your client class to enqueue jobs with that class:
 
 ```ruby
@@ -289,6 +316,7 @@ option, to serve as a guard clause filter.
 
 [after_perform]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
 [retry_on]: https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-retry_on
+[discard_on]: https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-discard_on
 
 ## Configuration
 

--- a/test/integration/action_client/active_job_test.rb
+++ b/test/integration/action_client/active_job_test.rb
@@ -3,6 +3,178 @@ require "active_job_test_case"
 
 module ActionClient
   class ActiveJobTest < ActionClient::ActiveJobTestCase
+    class RetryOnWithStatusOptionsTest < ActiveJobTest
+      test ".retry_on without options always executes" do
+        job = declare_job {
+          retry_on(Timeout::Error)
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping")
+          .to_raise(Timeout::Error)
+          .then.to_return(status: 200)
+
+        perform_enqueued_jobs { client.ping.submit_later }
+
+        assert_requested :get, "https://example.com/ping", times: 2
+      end
+
+      test ".retry_on accepts other options" do
+        job = declare_job {
+          retry_on(Timeout::Error, attempts: 1)
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping")
+          .to_raise(Timeout::Error)
+          .then.to_return(status: 200)
+
+        assert_raises(Timeout::Error) do
+          perform_enqueued_jobs { client.ping.submit_later }
+        end
+
+        assert_requested :get, "https://example.com/ping", times: 1
+        assert_performed_jobs(1)
+      end
+
+      test ".retry_on raises when passed both only_status: and except_status:" do
+        exception = assert_raises(ArgumentError) {
+          declare_job {
+            retry_on(only_status: 200, except_status: 200)
+          }
+        }
+
+        assert_includes exception.message, "except_status:"
+        assert_includes exception.message, "only_status:"
+      end
+
+      test ".retry_on accepts both Error arguments and status options" do
+        job = declare_job {
+          retry_on(StandardError, only_status: 500)
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping")
+          .to_raise(StandardError)
+          .then.to_return(status: 500)
+          .then.to_return(status: 200)
+
+        perform_enqueued_jobs { client.ping.submit_later }
+
+        assert_requested :get, "https://example.com/ping", times: 3
+      end
+
+      test ".retry_on with only_status retries for a matching status" do
+        job = declare_job {
+          retry_on(only_status: 500)
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping")
+          .to_return(status: 500)
+          .then.to_return(status: 200)
+
+        perform_enqueued_jobs { client.ping.submit_later }
+
+        assert_requested :get, "https://example.com/ping", times: 2
+      end
+
+      test ".retry_on yields the error to a block" do
+        exception = nil
+        job = declare_job {
+          retry_on(only_status: 500) { |_, e| exception = e }
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping").to_return(status: 500)
+
+        perform_enqueued_jobs { client.ping.submit_later }
+
+        assert_includes exception.message, "500"
+      end
+
+      test ".retry_on with only_status does not retry when the status does not matching" do
+        job = declare_job {
+          retry_on(only_status: 500)
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping").to_return(status: 200)
+
+        perform_enqueued_jobs { client.ping.submit_later }
+
+        assert_requested :get, "https://example.com/ping", times: 1
+      end
+
+      test ".retry_on with except_status retries for a matching status" do
+        job = declare_job {
+          retry_on(except_status: 200)
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping")
+          .to_return(status: 500)
+          .then.to_return(status: 200)
+
+        perform_enqueued_jobs { client.ping.submit_later }
+
+        assert_requested :get, "https://example.com/ping", times: 2
+      end
+
+      test ".retry_on with except_status does not retry when a status does not match" do
+        job = declare_job {
+          retry_on(except_status: 200)
+        }
+        client = declare_client {
+          self.submission_job = job
+
+          def ping
+            get url: "https://example.com/ping"
+          end
+        }
+        stub_request(:get, "https://example.com/ping").to_return(status: 200)
+
+        perform_enqueued_jobs { client.ping.submit_later }
+
+        assert_requested :get, "https://example.com/ping", times: 1
+      end
+    end
+
     class AfterPerformWithoutOptionsTest < ActiveJobTest
       test ".after_perform without options always executes" do
         response = nil


### PR DESCRIPTION
Integrate with ActiveJob retry_on
===

To automatically retry jobs matching a single HTTP Status or
a collection of HTTP Status Codes, declare a `retry_on` block:

```ruby
class ArticlesClientJob < ActionClient::SubmissionJob
  retry_on except_status: 200, queue: "low_priority"
end
```

Under the hood, this method declares a [`retry_on` block][retry_on], so
you can mix and match `except_status:` and `only_status:` options with
the other arguments `retry_on` accepts:

```ruby
class ArticlesClientJob < ActionClient::SubmissionJob
  retry_on Net::OpenTimeout, except_status: 200, queue: "low_priority"
end
```

[retry_on]: https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-retry_on

Integrate with ActiveJob discard_on
===

To skip retrying jobs matching a single HTTP Status or a collection of
HTTP Status Codes, declare a `discard_on` block:

```ruby
class ArticlesClientJob < ActionClient::SubmissionJob
  retry_on except_status: 200, queue: "low_priority"
  discard_on only_status: 422
end
```

Under the hood, this method declares a [`discard_on` block][discard_on],
so you can mix and match `except_status:` and `only_status:` options
with the other arguments `discard_on` accepts:

```ruby
class ArticlesClientJob < ActionClient::SubmissionJob
  retry_on Net::OpenTimeout
  discard_on Articles::Api::InvalidError, only_status: 422
end
```

[discard_on]: https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-discard_on

