### PR TITLE
Instrument with ActiveSupport::Notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Instrument request lifecyle with `ActiveSupport::Notifications` (added by
+  [@seanpdoyle][])
+
 - Implicitly call `default` with `url:` and `headers:` declarations from a
   client's `config/clients` YAML file (added by [@seanpdoyle][])
 

--- a/README.md
+++ b/README.md
@@ -740,6 +740,31 @@ end
 [test-adapter]: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/TestAdapter.html
 [inline-adapter]: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/InlineAdapter.html
 
+## Instrumentation
+
+Various events throughout the lifecycle of an HTTP Request emit
+[`ActiveSupport::Notifications` events][ActiveSupport::Notifications] events:
+
+* `submit.action_client` - instruments the entire Request submission
+  * Payload:
+    * `client` - the instance of the `ActionClient::Base` descendant
+    * `action_name` - the request's action name
+    * `action_arguments` - the arguments passed to the action
+    * `request` - the underlying [`ActionDispatch::Request` instance][ActionDispatch::Request]
+
+* `http_request.action_client` - instruments the HTTP Request
+  * Payload:
+    * `request` - the underlying [`ActionDispatch::Request` instance][ActionDispatch::Request]
+
+* `parse.action_client` - instruments the Response body parsing
+  * Payload:
+    * `content_type` - the response [Content-Type][]
+    * `body` - the response body String
+
+[ActiveSupport::Notifications]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html
+[ActionDispatch::Request]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html
+[Content-Type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/lib/action_client/applications/net/http_client.rb
+++ b/lib/action_client/applications/net/http_client.rb
@@ -20,6 +20,19 @@ module ActionClient
             http_request[key] = value
           end
 
+          ActiveSupport::Notifications.instrument(
+            "http_request.action_client",
+            uri: uri,
+            http_request: http_request,
+            method: request.request_method
+          ) do
+            submit(http_request, uri)
+          end
+        end
+
+        private
+
+        def submit(http_request, uri)
           response = ::Net::HTTP.start(
             uri.hostname,
             uri.port,

--- a/lib/action_client/engine.rb
+++ b/lib/action_client/engine.rb
@@ -14,8 +14,11 @@ module ActionClient
       ActionClient::Base.middleware = ActionDispatch::MiddlewareStack.new do |stack|
         stack.use ActionClient::Middleware::Parser, config.action_client
         stack.use Rack::ContentLength
-        stack.use Rails::Rack::Logger, [ActionClient::Middleware::Tagger]
       end
+    end
+
+    initializer "action_client.logging" do
+      ActionClient::LogSubscriber.attach_to :action_client
     end
 
     initializer "action_client.routes" do |app|

--- a/lib/action_client/log_subscriber.rb
+++ b/lib/action_client/log_subscriber.rb
@@ -4,10 +4,10 @@ module ActionClient
       client = event.payload[:client]
       action_name = event.payload[:action_name]
       request = event.payload[:request]
-      action_name = color("#{client.class}##{action_name}", CYAN, true)
-      http = color("#{request.method} #{request.url}", CYAN, true)
+      action_name = "#{client.class}##{action_name}"
+      http = "#{request.method} #{request.url}"
 
-      info "#{action_name} - #{http} - #{duration(event)}"
+      info "#{action_name} - #{http} #{duration(event)}"
     end
 
     private

--- a/lib/action_client/log_subscriber.rb
+++ b/lib/action_client/log_subscriber.rb
@@ -1,0 +1,19 @@
+module ActionClient
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    def submit(event)
+      client = event.payload[:client]
+      action_name = event.payload[:action_name]
+      request = event.payload[:request]
+      action_name = color("#{client.class}##{action_name}", CYAN, true)
+      http = color("#{request.method} #{request.url}", CYAN, true)
+
+      info "#{action_name} - #{http} - #{duration(event)}"
+    end
+
+    private
+
+    def duration(event)
+      "(Duration #{event.duration.truncate(2)}ms)"
+    end
+  end
+end

--- a/lib/action_client/middleware/parser.rb
+++ b/lib/action_client/middleware/parser.rb
@@ -36,16 +36,22 @@ module ActionClient
           request.headers["Accept"]
         ).to_s
 
-        if body.present?
-          parser = fetch_parser_for_content_type(content_type)
+        ActiveSupport::Notifications.instrument(
+          "parse.action_client",
+          content_type: content_type,
+          body: body
+        ) do
+          if body.present?
+            parser = fetch_parser_for_content_type(content_type)
 
-          begin
-            [status, headers, parser.call(body)]
-          rescue => error
-            raise ActionClient::ParseError.new(error, body, content_type)
+            begin
+              [status, headers, parser.call(body)]
+            rescue => error
+              raise ActionClient::ParseError.new(error, body, content_type)
+            end
+          else
+            [status, headers, body]
           end
-        else
-          [status, headers, body]
         end
       end
 

--- a/lib/action_client/middleware/tagger.rb
+++ b/lib/action_client/middleware/tagger.rb
@@ -1,7 +1,0 @@
-module ActionClient
-  module Middleware
-    Tagger = proc do |request|
-      "ActionClient - #{request.request_method} - #{request.original_url}"
-    end
-  end
-end

--- a/test/integration/action_client/instrumentation_test.rb
+++ b/test/integration/action_client/instrumentation_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+require "integration_test_case"
+
+module ActionClient
+  class InstrumentationTest < ActionClient::IntegrationTestCase
+    test "instruments submit.action_client during submission" do
+      client = declare_client {
+        def all(**query)
+          get url: "https://example.com/articles", query: query
+        end
+      }
+      stub_request(:get, "https://example.com/articles?page=1")
+      assertions = proc do |name, start, finish, id, payload|
+        assert_predicate finish - start, :positive?
+        assert_kind_of client, payload[:client]
+        assert_equal "GET", payload[:request].request_method
+        assert_equal "all", payload[:action_name]
+        assert_equal [{page: 1}], payload[:action_arguments]
+      end
+
+      ActiveSupport::Notifications.subscribed(assertions, "submit.action_client") do
+        client.all(page: 1).submit
+      end
+    end
+
+    test "instruments http_request.action_client during submission" do
+      client = declare_client {
+        def all
+          get url: "https://example.com/articles"
+        end
+      }
+      stub_request(:get, "https://example.com/articles")
+      assertions = proc do |name, start, finish, id, payload|
+        assert_predicate finish - start, :positive?
+        assert_equal "GET", payload[:method]
+        assert_equal URI("https://example.com/articles"), payload[:uri]
+        assert_includes payload, :http_request
+      end
+
+      ActiveSupport::Notifications.subscribed(assertions, "http_request.action_client") do
+        client.all.submit
+      end
+    end
+
+    test "instruments parse.action_client during submission" do
+      client = declare_client {
+        def all
+          get url: "https://example.com/articles"
+        end
+      }
+      stub_request(:get, "https://example.com/articles").and_return(
+        headers: {"Content-Type": "application/json"},
+        body: %({"status": "success"})
+      )
+      assertions = proc do |name, start, finish, id, payload|
+        assert_predicate finish - start, :positive?
+        assert_equal "application/json", payload[:content_type]
+        assert_equal %({"status": "success"}), payload[:body]
+      end
+
+      ActiveSupport::Notifications.subscribed(assertions, "parse.action_client") do
+        client.all.submit
+      end
+    end
+  end
+end

--- a/test/lib/action_client/log_subscriber_test.rb
+++ b/test/lib/action_client/log_subscriber_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+require "integration_test_case"
+require "active_support/log_subscriber/test_helper"
+
+module ActionClient
+  class LogSubscriberTest < ActionClient::IntegrationTestCase
+    include ActiveSupport::LogSubscriber::TestHelper
+
+    def setup
+      super
+      ActionClient::LogSubscriber.attach_to :action_client
+    end
+
+    test "submit.action_client logs lifecycle events" do
+      client = declare_client("ArticlesClient") {
+        def all
+          get url: "https://example.com/articles"
+        end
+      }
+      stub_request(:get, "https://example.com/articles").to_return(
+        body: %({"status": "success"}),
+        headers: {"Content-Type": "application/json"}
+      )
+
+      client.all.submit
+      wait
+
+      assert_logged(:info, "ArticlesClient#all - GET https://example.com/articles")
+    end
+
+    def assert_logged(level, message)
+      lines = @logger.logged(level)
+
+      messages_in_logs = lines.any? { |line| line.include?(message) }
+
+      assert messages_in_logs, <<~FAIL
+        Expected #{level} logs to include:
+
+        #{message.indent(2)}
+
+        but was
+
+        #{lines.map { |line| line.indent(2) }.join("\n")}
+
+      FAIL
+    end
+  end
+end


### PR DESCRIPTION
Instrument various events throughout the life-cycle of an HTTP Request
emit [`ActiveSupport::Notifications`
events][ActiveSupport::Notifications]

* `http_request.action_client` - instruments the HTTP Request
  * Payload:
    * `request` - the underlying [`ActionDispatch::Request` instance][ActionDispatch::Request]

* `parse.action_client` - instruments the Response body parsing
  * Payload:
    * `content_type` - the response [Content-Type][]
    * `body` - the response body String

* `submit.action_client` - instruments the entire Request submission
  * Payload:
    * `client` - the instance of the `ActionClient::Base` descendant
    * `action_name` - the request's action name
    * `action_arguments` - the arguments passed to the action
    * `request` - the underlying [`ActionDispatch::Request` instance][ActionDispatch::Request]

[ActiveSupport::Notifications]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html
[ActionDispatch::Request]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html
[Content-Type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type

Additionally, this commit introduces the `ActionClient::LogSubscriber`,
built atop the
[`ActiveSupport::LogSubscriber`][ActiveSupport::LogSubscriber] to
increase the visibility of the inner mechanics of the request-response
cycle.

[ActiveSupport::Notifications]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html
[ActiveSupport::LogSubscriber]: https://api.rubyonrails.org/classes/ActiveSupport/LogSubscriber.html

standard fixes

